### PR TITLE
Fix build

### DIFF
--- a/thirdparty/curl/BUILD
+++ b/thirdparty/curl/BUILD
@@ -1,35 +1,46 @@
 include('//thirdparty/foreign_build.bld')
 
-_SSL_PATH = blade.path.join(blade.path.dirname(blade.path.abspath(blade.current_target_dir())), 'openssl')
-_NGHTTP2_PATH = blade.path.join(blade.path.dirname(blade.path.abspath(blade.current_target_dir())), 'nghttp2')
+_SSL_PATH = get_install_dir('openssl')
+_NGHTTP2_PATH = get_install_dir('nghttp2')
+_ZLIB_PATH = get_install_dir('zlib')
 
 autotools_build(
-    name = 'curl_build',
-    source_package = 'curl-7.71.0.tar.bz2',
-    package_name = 'curl',
-    lib_names = ['curl'],
-    configure_options = '--with-nghttp2=' + _NGHTTP2_PATH + ' --with-ssl=' + _SSL_PATH + ' --enable-shared --enable-static --with-pic  --disable-ldap --disable-ldaps',
-    deps = [
-      '//thirdparty/nghttp2:nghttp2',
-      '//thirdparty/openssl:crypto',
-      '//thirdparty/openssl:ssl',
+    name='curl_build',
+    source_package='curl-7.71.0.tar.bz2',
+    package_name='curl',
+    lib_names=['curl'],
+    configure_options=' '.join([
+        '--with-nghttp2=' + _NGHTTP2_PATH,
+        '--with-ssl=' + _SSL_PATH,
+        '--with-zlib=' + _ZLIB_PATH,
+        '--enable-shared',
+        '--enable-static',
+        '--with-pic',
+        '--disable-ldap',
+        '--disable-ldaps',
+    ]),
+    deps=[
+        '//thirdparty/nghttp2:nghttp2',
+        '//thirdparty/openssl:crypto',
+        '//thirdparty/openssl:ssl',
+        '//thirdparty/zlib:z',
     ],
-    ld_library_path = [_SSL_PATH + '/lib', _NGHTTP2_PATH + '/lib'],
+    ld_library_path=[_SSL_PATH + '/lib', _NGHTTP2_PATH + '/lib'],
     strip_include_prefix='curl',
     generate_dynamic=True,
 )
 
 foreign_cc_library(
-    name = 'curl',
+    name='curl',
     deps=[
-      ':curl_build',
-      '#pthread',
-      '#rt',
-      '#z',
-      '//thirdparty/openssl:crypto',
-      '//thirdparty/openssl:ssl',
-      '//thirdparty/nghttp2:nghttp2',
+        ':curl_build',
+        '//thirdparty/nghttp2:nghttp2',
+        '//thirdparty/openssl:crypto',
+        '//thirdparty/openssl:ssl',
+        '//thirdparty/zlib:z',
+        '#pthread',
+        '#rt',
     ],
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
     has_dynamic=True,
 )

--- a/thirdparty/foreign_build.bld
+++ b/thirdparty/foreign_build.bld
@@ -305,3 +305,6 @@ def cmake_cc_library(
         package_name=name,
         deps=[':' + target_build] + with_packages + deps,
         export_incs=blade.path.join(install_dir, include_dir))
+
+def get_install_dir(name):
+    return blade.path.join(blade.path.dirname(blade.path.abspath(blade.current_target_dir())), name)

--- a/thirdparty/gflags/BUILD
+++ b/thirdparty/gflags/BUILD
@@ -11,8 +11,12 @@ cmake_build(
         '-DGFLAGS_BUILD_STATIC_LIBS=ON',
         '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
         '-DCMAKE_BUILD_TYPE=Release',
+        '-DZLIB_ROOT=' + get_install_dir('zlib'),
     ],
-    strip_include_prefix = 'gflags',
+    deps=[
+        '//thirdparty/zlib:z',
+    ],
+    strip_include_prefix='gflags',
     generate_dynamic=True,
 )
 
@@ -20,12 +24,12 @@ foreign_cc_library(
     name='gflags',
     deps=[
         ':gflags_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 cc_test(

--- a/thirdparty/glog/BUILD
+++ b/thirdparty/glog/BUILD
@@ -19,6 +19,7 @@ autotools_build(
         '//thirdparty/gflags:gflags',
         '//thirdparty/zlib:z',
     ],
+    patches=['disable_libunwind.patch'],
     strip_include_prefix='glog',
     configure_file_name='./autogen.sh && ./configure',
     generate_dynamic=True,

--- a/thirdparty/glog/BUILD
+++ b/thirdparty/glog/BUILD
@@ -1,18 +1,23 @@
 include('../foreign_build.bld')
 
-_GFLAGS_PATH = blade.path.join(
-    blade.path.dirname(blade.path.abspath(blade.current_target_dir())),
-    'gflags')
+_GFLAGS_PATH = get_install_dir('gflags')
+_ZLIB_PATH = get_install_dir('zlib')
 
 autotools_build(
     name='glog_build',
     source_package='glog-0.4.0.tar.gz',
     package_name='glog',
     lib_names=['glog'],
-    configure_options='--with-gflags=' + _GFLAGS_PATH +
-    ' --enable-shared --enable-static --with-pic',
+    configure_options=' '.join([
+        '--with-gflags=' + _GFLAGS_PATH,
+        '--with-zlib=' + _ZLIB_PATH,
+        '--enable-shared',
+        '--enable-static',
+        '--with-pic',
+    ]),
     deps=[
         '//thirdparty/gflags:gflags',
+        '//thirdparty/zlib:z',
     ],
     strip_include_prefix='glog',
     configure_file_name='./autogen.sh && ./configure',
@@ -23,12 +28,12 @@ foreign_cc_library(
     name='glog',
     deps=[
         ':glog_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 cc_test(name='glog_test',

--- a/thirdparty/glog/ChangeLog
+++ b/thirdparty/glog/ChangeLog
@@ -1,9 +1,0 @@
-* navywu: 日志输出到终端时，增加了颜色。
-* happyluo: add error message hooker for user
-* chen3feng: 支持 bool 类型参数 --strip_source_path，log 里输出完整的原文件路径，默认为
-false
-* chen3feng: 没有设置 log_dir 时，优先使用当前目录，原来输出到 /tmp，很容易造成磁盘满告警。
-* chen3feng: RAW_LOG(FATAL) 在开启 Strip 时，调用 exit，如果本身是在 exit中，就会造成 exit
-			递归调用，应该跟不 strip 一样调 abort()
-* chen3feng: 避免在 FlushLogFilesUnsafe 里分配内存，否则在信号处理或者 tcmalloc
-abort 时会死锁。

--- a/thirdparty/glog/disable_libunwind.patch
+++ b/thirdparty/glog/disable_libunwind.patch
@@ -1,0 +1,20 @@
+diff -uNr a/configure.ac b/configure.ac
+--- a/configure.ac	2021-05-31 12:33:03.683544680 +0800
++++ b/configure.ac	2021-05-31 12:34:33.675544680 +0800
+@@ -180,16 +180,6 @@
+ 
+ # We want to link in libunwind if it exists
+ UNWIND_LIBS=
+-# Unfortunately, we need to check the header file in addition to the
+-# lib file to check if libunwind is available since libunwind-0.98
+-# doesn't install all necessary header files.
+-if test x"$ac_cv_have_libunwind_h" = x"1"; then
+- AC_CHECK_LIB(unwind, backtrace, UNWIND_LIBS=-lunwind)
+-fi
+-AC_SUBST(UNWIND_LIBS)
+-if test x"$UNWIND_LIBS" != x""; then
+-  AC_DEFINE(HAVE_LIB_UNWIND, 1, [define if you have libunwind])
+-fi
+ 
+ # We'd like to use read/write locks in several places in the code.
+ # See if our pthreads support extends to that.  Note: for linux, it

--- a/thirdparty/gperftools/BUILD
+++ b/thirdparty/gperftools/BUILD
@@ -1,7 +1,7 @@
 include('../foreign_build.bld')
 
-_GFLAGS_PATH = blade.path.join(
-    blade.path.dirname(blade.path.abspath(blade.current_target_dir())), 'gflags')
+_GFLAGS_PATH = get_install_dir('gflags')
+_ZLIB_PATH = get_install_dir('zlib')
 
 autotools_build(
     name='gperftools_build',
@@ -12,13 +12,15 @@ autotools_build(
         'tcmalloc_minimal', 'tcmalloc_minimal_debug'
     ],
     configure_options=' '.join([
-        '--with-gflags=' + _GFLAGS_PATH, ' --enable-shared', '--enable-static',
-        '--with-pic', '--enable-heap-checker', '--enable-heap-profiler',
+        '--with-gflags=' + _GFLAGS_PATH, '--with-zlib=' + _ZLIB_PATH,
+        '--enable-shared', '--enable-static', '--with-pic',
+        '--enable-heap-checker', '--enable-heap-profiler',
         '--enable-cpu-profiler', '--enable-debugalloc',
         '--enable-frame-pointers'
     ]),
     deps=[
         '//thirdparty/gflags:gflags',
+        '//thirdparty/zlib:z',
     ],
     strip_include_prefix='gperftools',
     configure_file_name='./configure',
@@ -29,76 +31,76 @@ foreign_cc_library(
     name='profiler',
     deps=[
         ':gperftools_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     export_incs='//' + blade.path.join(blade.current_target_dir(), 'include'),
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 foreign_cc_library(
     name='tcmalloc',
     deps=[
         ':gperftools_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     export_incs='//' + blade.path.join(blade.current_target_dir(), 'include'),
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 foreign_cc_library(
     name='tcmalloc_and_profiler',
     deps=[
         ':gperftools_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     export_incs='//' + blade.path.join(blade.current_target_dir(), 'include'),
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 foreign_cc_library(
     name='tcmalloc_debug',
     deps=[
         ':gperftools_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     export_incs='//' + blade.path.join(blade.current_target_dir(), 'include'),
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 foreign_cc_library(
     name='tcmalloc_minimal',
     deps=[
         ':gperftools_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     export_incs='//' + blade.path.join(blade.current_target_dir(), 'include'),
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )
 
 foreign_cc_library(
     name='tcmalloc_minimal_debug',
     deps=[
         ':gperftools_build',
+        '//thirdparty/zlib:z',
         '#pthread',
         '#rt',
-        '#z',
     ],
     export_incs='//' + blade.path.join(blade.current_target_dir(), 'include'),
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )

--- a/thirdparty/gperftools/BUILD
+++ b/thirdparty/gperftools/BUILD
@@ -16,7 +16,7 @@ autotools_build(
         '--enable-shared', '--enable-static', '--with-pic',
         '--enable-heap-checker', '--enable-heap-profiler',
         '--enable-cpu-profiler', '--enable-debugalloc',
-        '--enable-frame-pointers'
+        '--enable-frame-pointers', '--disable-libunwind',
     ]),
     deps=[
         '//thirdparty/gflags:gflags',

--- a/thirdparty/jemalloc/BUILD
+++ b/thirdparty/jemalloc/BUILD
@@ -20,8 +20,7 @@ foreign_cc_library(
         ':jemalloc_build',
         '#pthread',
         '#rt',
-        '#z',
     ],
     has_dynamic=True,
-    visibility = 'PUBLIC',
+    visibility='PUBLIC',
 )

--- a/thirdparty/snappy/BUILD
+++ b/thirdparty/snappy/BUILD
@@ -1,24 +1,27 @@
 include('//thirdparty/foreign_build.bld')
 
-cmake_build(
-    name='snappy_build',
-    source_package='snappy-1.1.8.tar.gz',
-    package_name='snappy',
-    lib_names=['snappy'],
-    cmake_options=[
-        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
-        '-DCMAKE_BUILD_TYPE=Release',
-        '-DSNAPPY_BUILD_TESTS=OFF',
-    ],
-    patches=['generate_dynamic.patch'],
-    generate_dynamic=True)
+cmake_build(name='snappy_build',
+            source_package='snappy-1.1.8.tar.gz',
+            package_name='snappy',
+            lib_names=['snappy'],
+            cmake_options=[
+                '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
+                '-DCMAKE_BUILD_TYPE=Release',
+                '-DSNAPPY_BUILD_TESTS=OFF',
+                '-DZLIB_ROOT=' + get_install_dir('zlib'),
+            ],
+            deps=[
+                '//thirdparty/zlib:z',
+            ],
+            patches=['generate_dynamic.patch'],
+            generate_dynamic=True)
 
 foreign_cc_library(
     name='snappy',
     deps=[
         ':snappy_build',
+        '//thirdparty/zlib:z',
         '#rt',
-        '#z',
     ],
     visibility='PUBLIC',
     has_dynamic=True,


### PR DESCRIPTION
- Now we no longer use libz installed on the host-system, the one under `thirdparty/` will be used.
- Addressing #13.

Note that it's still not working on Ubuntu, linker does not work as expected there:

- Linking against `ctemplate` raises an undefined reference to `pthread_once`.
- `link_all_symbols=True` does not work.