### PR TITLE
Fixing possible name lookup failure when using flare/base/enum.h to provide bitmask operations.

### DIFF
--- a/flare/base/enum.h
+++ b/flare/base/enum.h
@@ -19,19 +19,6 @@
 
 namespace flare {
 
-// Specialize this trait and specify `value` to true for enabling bit-fields
-// operators.
-//
-// `T` must be an enumeration type.
-template <class T>
-struct is_enum_bitmask_enabled {
-  static constexpr bool value = false;
-};
-
-}  // namespace flare
-
-namespace flare {
-
 // But why don't you simply use `std::underlying_type_t<T>(v)`, instead of using
 // this one?
 template <class T, class = std::enable_if_t<std::is_enum_v<T>>>
@@ -41,60 +28,44 @@ constexpr auto underlying_value(T v) {
 
 }  // namespace flare
 
-// Intentionally put into global namespace.
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T operator|(T left, T right) {
-  return static_cast<T>(flare::underlying_value(left) |
-                        flare::underlying_value(right));
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T& operator|=(T& left, T right) {
-  left = left | right;
-  return left;
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T operator&(T left, T right) {
-  return static_cast<T>(flare::underlying_value(left) &
-                        flare::underlying_value(right));
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T& operator&=(T& left, T right) {
-  left = left & right;
-  return left;
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T operator^(T left, T right) {
-  return static_cast<T>(flare::underlying_value(left) ^
-                        flare::underlying_value(right));
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T& operator^=(T& left, T right) {
-  left = left ^ right;
-  return left;
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr T operator~(T value) {
-  return static_cast<T>(~flare::underlying_value(value));
-}
-
-template <class T,
-          class = std::enable_if_t<flare::is_enum_bitmask_enabled<T>::value>>
-constexpr bool operator!(T value) {
-  return !flare::underlying_value(value);
-}
+// Allow `Type` to be used as a bitmask.
+#define FLARE_DEFINE_ENUM_BITMASK_OPS(Type)                    \
+  constexpr Type operator|(Type left, Type right) {            \
+    return static_cast<Type>(flare::underlying_value(left) |   \
+                             flare::underlying_value(right));  \
+  }                                                            \
+                                                               \
+  constexpr Type& operator|=(Type& left, Type right) {         \
+    left = left | right;                                       \
+    return left;                                               \
+  }                                                            \
+                                                               \
+  constexpr Type operator&(Type left, Type right) {            \
+    return static_cast<Type>(flare::underlying_value(left) &   \
+                             flare::underlying_value(right));  \
+  }                                                            \
+                                                               \
+  constexpr Type& operator&=(Type& left, Type right) {         \
+    left = left & right;                                       \
+    return left;                                               \
+  }                                                            \
+                                                               \
+  constexpr Type operator^(Type left, Type right) {            \
+    return static_cast<Type>(flare::underlying_value(left) ^   \
+                             flare::underlying_value(right));  \
+  }                                                            \
+                                                               \
+  constexpr Type& operator^=(Type& left, Type right) {         \
+    left = left ^ right;                                       \
+    return left;                                               \
+  }                                                            \
+                                                               \
+  constexpr Type operator~(Type value) {                       \
+    return static_cast<Type>(~flare::underlying_value(value)); \
+  }                                                            \
+                                                               \
+  constexpr bool operator!(Type value) {                       \
+    return !flare::underlying_value(value);                    \
+  }
 
 #endif  // FLARE_BASE_ENUM_H_

--- a/flare/base/enum_test.cc
+++ b/flare/base/enum_test.cc
@@ -18,32 +18,46 @@
 
 #include "thirdparty/googletest/gtest/gtest.h"
 
-namespace flare {
+namespace ns1 {
+
+enum class Byte : int {};
+
+FLARE_DEFINE_ENUM_BITMASK_OPS(Byte);
+
+}  // namespace ns1
+
+namespace ns2 {
+
+// This should interfere with operator&(ns1::Byte, ns1::Byte);
+template <class T, class U>
+int operator&(T&&, U&&) {
+  return 0;
+}
 
 TEST(Enum, UnderlyingValue) {
-  std::byte b{10};
-  ASSERT_EQ(10, underlying_value(b));
+  ns1::Byte b{10};
+  ASSERT_EQ(10, flare::underlying_value(b));
 }
 
 TEST(Enum, OperatorOr) {
-  std::byte a{1}, b{2};
-  ASSERT_EQ(3, underlying_value(a | b));
+  ns1::Byte a{1}, b{2};
+  ASSERT_EQ(3, flare::underlying_value(a | b));
   a |= b;
-  ASSERT_EQ(3, underlying_value(a));
+  ASSERT_EQ(3, flare::underlying_value(a));
 }
 
 TEST(Enum, OperatorAnd) {
-  std::byte a{3}, b{2};
-  ASSERT_EQ(2, underlying_value(a & b));
+  ns1::Byte a{3}, b{2};
+  ASSERT_EQ(2, flare::underlying_value(a & b));
   a &= b;
-  ASSERT_EQ(2, underlying_value(a));
+  ASSERT_EQ(2, flare::underlying_value(a));
 }
 
 TEST(Enum, OperatorXor) {
-  std::byte a{2}, b{2};
-  ASSERT_EQ(0, underlying_value(a ^ b));
+  ns1::Byte a{2}, b{2};
+  ASSERT_EQ(0, flare::underlying_value(a ^ b));
   a ^= b;
-  ASSERT_EQ(0, underlying_value(a));
+  ASSERT_EQ(0, flare::underlying_value(a));
 }
 
-}  // namespace flare
+}  // namespace ns2

--- a/flare/io/descriptor.h
+++ b/flare/io/descriptor.h
@@ -185,14 +185,7 @@ class alignas(hardware_destructive_interference_size) Descriptor
   } read_mostly_;
 };
 
-}  // namespace flare
-
-namespace flare {
-
-template <>
-struct is_enum_bitmask_enabled<Descriptor::Event> {
-  static constexpr bool value = true;
-};
+FLARE_DEFINE_ENUM_BITMASK_OPS(Descriptor::Event);
 
 }  // namespace flare
 

--- a/flare/rpc/protocol/message.h
+++ b/flare/rpc/protocol/message.h
@@ -127,10 +127,7 @@ class MessageFactory {
   static const MessageFactory* null_factory;
 };
 
-template <>
-struct is_enum_bitmask_enabled<Message::Type> {
-  static constexpr auto value = true;
-};
+FLARE_DEFINE_ENUM_BITMASK_OPS(Message::Type);
 
 }  // namespace flare
 

--- a/flare/rpc/protocol/protobuf/message.h
+++ b/flare/rpc/protocol/protobuf/message.h
@@ -142,10 +142,7 @@ struct PoolTraits<rpc::RpcMeta> {
   static void OnGet(rpc::RpcMeta* p) { p->Clear(); }
 };
 
-template <>
-struct is_enum_bitmask_enabled<rpc::MessageFlags> {
-  static constexpr auto value = true;
-};
+FLARE_DEFINE_ENUM_BITMASK_OPS(rpc::MessageFlags);
 
 }  // namespace flare
 

--- a/flare/rpc/protocol/stream_protocol.h
+++ b/flare/rpc/protocol/stream_protocol.h
@@ -161,6 +161,8 @@ FLARE_DECLARE_CLASS_DEPENDENCY_REGISTRY(client_side_stream_protocol_registry,
 FLARE_DECLARE_CLASS_DEPENDENCY_REGISTRY(server_side_stream_protocol_registry,
                                         StreamProtocol);
 
+FLARE_DEFINE_ENUM_BITMASK_OPS(StreamProtocol::MessageCutStatus);
+
 }  // namespace flare
 
 // Define protocol by its class name.
@@ -194,14 +196,5 @@ FLARE_DECLARE_CLASS_DEPENDENCY_REGISTRY(server_side_stream_protocol_registry,
   FLARE_REGISTER_CLASS_DEPENDENCY_FACTORY(                  \
       flare::server_side_stream_protocol_registry, Name,    \
       [] { return std::make_unique<Implementation>(__VA_ARGS__); })
-
-namespace flare {
-
-template <>
-struct is_enum_bitmask_enabled<StreamProtocol::MessageCutStatus> {
-  static constexpr bool value = true;
-};
-
-}  // namespace flare
 
 #endif  // FLARE_RPC_PROTOCOL_STREAM_PROTOCOL_H_


### PR DESCRIPTION
This led to compilation error if both flare/base/option.h and flare/rpc/rpc_client_controller.h were included in same file.

Now we use macro to define operator overloads so that they're always visible via ADL (provided the macro is instantiated in the same namespace as the enum type.)