### PR TITLE
Optimizing object pool a bit. 

### DIFF
--- a/flare/base/object_pool/memory_node_shared.h
+++ b/flare/base/object_pool/memory_node_shared.h
@@ -260,7 +260,7 @@ inline void* Get() {
   auto&& local = descriptors_ptr<T>.local;
   if (FLARE_LIKELY(local /* Initialized */ && !local->objects.empty())) {
     // Thread local cache hit.
-    return local->objects.pop_back()->first;
+    return local->objects.pop_back();
   }
   return InitializeOptAndGetSlow<T>();
 }
@@ -269,7 +269,7 @@ template <class T>
 inline void Put(void* ptr) {
   auto&& [desc, global, local] = descriptors_ptr<T>;
   if (FLARE_LIKELY(local /* Initialized */ && !local->objects.full())) {
-    local->objects.emplace_back(ptr, desc->destroy);
+    local->objects.emplace_back(ptr);
     return;
   }
   return InitializeOptAndPutSlow<T>(ptr);


### PR DESCRIPTION
GCC isn't clever enough to eliminate all dead stores. Besides, we don't have to store a copy of destroyer along with every object.

Besides, I missed a data structure that should be `std::hardware_destructive_interference_size` aligned.

When tested with our echo server (`example/rpc/server.cc`), this optimization reduces slow path of `Get`-ting fiber stacks (actually, moving them from central per-node pool) from ~2000ns down to ~900ns, `Put`-ting them from ~2000ns down to ~1000ns, respectively.