### PR TITLE
Object pool's thread-local buffer should be aligned to hardware destructive interference size as well.

### DIFF
--- a/flare/base/object_pool/memory_node_shared.h
+++ b/flare/base/object_pool/memory_node_shared.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 
+#include "flare/base/align.h"
 #include "flare/base/demangle.h"
 #include "flare/base/exposed_var.h"
 #include "flare/base/internal/annotation.h"
@@ -110,7 +111,7 @@ struct GlobalPoolDescriptor {
 };
 
 // Thread-local object cache.
-struct LocalPoolDescriptor {
+struct alignas(hardware_destructive_interference_size) LocalPoolDescriptor {
   // See comments on `FixedVector` for the reason why `std::vector<...>` is not
   // used here.
   FixedVector objects;


### PR DESCRIPTION
Here we're aligning `LocalPoolDescriptor`.

The main concern here is `FixedVector` inside it, which is frequently accessed.

Without explicit aligning it, inferior memory allocator may allocate thread-local buffer belong to different threads adjacently, leading to false-sharing.