### PR TITLE
curl 去掉brotlidec依赖

### DIFF
--- a/BLADE_ROOT
+++ b/BLADE_ROOT
@@ -106,6 +106,7 @@ cc_config(
         # We need this in some platforms for `link_all_symbols=True` to work.
         '-Wl,--no-as-needed',
         '-lpthread',
+        '-lbrotlidec',
     ],
     benchmark_libs=['//thirdparty/benchmark:benchmark'],
     benchmark_main_libs=['//thirdparty/benchmark:benchmark_main'],

--- a/BLADE_ROOT
+++ b/BLADE_ROOT
@@ -106,7 +106,6 @@ cc_config(
         # We need this in some platforms for `link_all_symbols=True` to work.
         '-Wl,--no-as-needed',
         '-lpthread',
-        '-lbrotlidec',
     ],
     benchmark_libs=['//thirdparty/benchmark:benchmark'],
     benchmark_main_libs=['//thirdparty/benchmark:benchmark_main'],

--- a/thirdparty/curl/BUILD
+++ b/thirdparty/curl/BUILD
@@ -18,6 +18,7 @@ autotools_build(
         '--with-pic',
         '--disable-ldap',
         '--disable-ldaps',
+        '--without-brotli',
     ]),
     deps=[
         '//thirdparty/nghttp2:nghttp2',


### PR DESCRIPTION
使用一台Fedora-workstation编译。编译多个目标的时候找不到Brotil相关的定义。系统上存在相关的库，增加了这个链接参数。编译通过。