### PR TITLE
feat#complete the Demangle function implementation in MSVC compiler

### DIFF
--- a/flare/base/demangle.cc
+++ b/flare/base/demangle.cc
@@ -14,7 +14,9 @@
 
 #include "flare/base/demangle.h"
 
+#ifdef __GNUC__
 #include <cxxabi.h>
+#endif
 
 #include <string>
 
@@ -22,8 +24,10 @@
 
 namespace flare {
 
-// TODO(luobogao): MSVC.
 std::string Demangle(const char* s) {
+#ifdef _MSC_VER
+  return s;
+#elif defined(__GNUC__)
   [[maybe_unused]] int status;
   auto demangled = abi::__cxa_demangle(s, nullptr, nullptr, &status);
   ScopedDeferred _([&] { free(demangled); });
@@ -31,6 +35,9 @@ std::string Demangle(const char* s) {
     return s;
   }
   return demangled;
+#else
+  #error "Demangle not supported on current compiler."
+#endif
 }
 
 }  // namespace flare

--- a/flare/base/ref_ptr.h
+++ b/flare/base/ref_ptr.h
@@ -96,7 +96,7 @@ class RefCounted {
   std::atomic<std::uint32_t> ref_count_{1};
 };
 
-// Keep the overhead the same as an atomic `std::uint3232_t`.
+// Keep the overhead the same as an atomic `std::uint32_t`.
 static_assert(sizeof(RefCounted<int>) == sizeof(std::atomic<std::uint32_t>));
 
 // Utilities for internal use.


### PR DESCRIPTION
typeid(instance).name() already returns the undecorated name since Microsoft Visio Studio 2019, and further demangling is not required.
`
struct Dummy {};

int main()
{
	std::cout << typeid(Dummy).name() << std::endl;
}

`
output:
struct Dummy
