### PR TITLE
Introducing message_dispatcher_factory. This allows us to move policy for determining NSLB out, and customize it (possibly by end-user) as needed.

### DIFF
--- a/flare/rpc/BUILD
+++ b/flare/rpc/BUILD
@@ -143,6 +143,35 @@ cc_library(
   visibility = 'PUBLIC',
 )
 
+cc_library(
+  name = 'message_dispatcher_factory',
+  hdrs = 'message_dispatcher_factory.h',
+  srcs = 'message_dispatcher_factory.cc',
+  deps = [
+    '//flare/base:function',
+    '//flare/base:never_destroyed',
+    '//flare/base/internal:hash_map',
+    '//flare/base/internal:macro',
+    '//flare/rpc/load_balancer:load_balancer',
+    '//flare/rpc/message_dispatcher:composited',
+    '//flare/rpc/message_dispatcher:message_dispatcher',
+    '//flare/rpc/name_resolver:name_resolver',
+  ]
+)
+
+cc_test(
+  name = 'message_dispatcher_factory_test',
+  srcs = 'message_dispatcher_factory_test.cc',
+  deps = [
+    ':message_dispatcher_factory',
+    '//flare/base:string',
+    '//flare/rpc/name_resolver:name_resolver',
+    '//flare/rpc/load_balancer:load_balancer',
+    '//flare/rpc/message_dispatcher:message_dispatcher',
+    '//flare/rpc/message_dispatcher:composited',
+  ]
+)
+
 #############################################
 # TARGET BELOW ARE FOR INTERNAL USE.        #
 #                                           #

--- a/flare/rpc/load_balancer/load_balancer.h
+++ b/flare/rpc/load_balancer/load_balancer.h
@@ -16,6 +16,7 @@
 #define FLARE_RPC_LOAD_BALANCER_LOAD_BALANCER_H_
 
 #include <chrono>
+#include <cstdint>
 #include <vector>
 
 #include "flare/base/dependency_registry.h"

--- a/flare/rpc/message_dispatcher_factory.cc
+++ b/flare/rpc/message_dispatcher_factory.cc
@@ -1,0 +1,120 @@
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "flare/rpc/message_dispatcher_factory.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "flare/base/internal/hash_map.h"
+#include "flare/base/never_destroyed.h"
+#include "flare/rpc/load_balancer/load_balancer.h"
+#include "flare/rpc/message_dispatcher/composited.h"
+#include "flare/rpc/name_resolver/name_resolver.h"
+
+namespace flare {
+
+namespace {
+
+// [Priority, Factory].
+using Factories = std::vector<std::pair<
+    int, Function<std::unique_ptr<MessageDispatcher>(std::string_view)>>>;
+
+using MessageDispatcherFactory =
+    Function<std::unique_ptr<MessageDispatcher>(std::string_view)>;
+using DefaultMessageDispatcherFactory =
+    Function<std::unique_ptr<MessageDispatcher>(std::string_view,
+                                                std::string_view)>;
+
+Factories* GetOrCreateFactoriesFor(std::string_view subsys,
+                                   std::string_view scheme) {
+  // I don't expect too many different factories for a given scheme. In this
+  // case linear-scan on a vector should perform better than (unordered_)map
+  // lookup.
+  static NeverDestroyed<internal::HashMap<
+      std::string, std::vector<std::pair<std::string, Factories>>>>
+      registry;
+  auto&& per_subsys = (*registry)[subsys];
+
+  for (auto&& [k, factories] : per_subsys) {
+    if (k == scheme) {
+      return &factories;
+    }
+  }
+  auto&& added = per_subsys.emplace_back();
+  added.first = scheme;
+  return &added.second;
+}
+
+DefaultMessageDispatcherFactory* GetDefaultMessageDispatcherFactory() {
+  static DefaultMessageDispatcherFactory factory =
+      [](auto&& subsys, auto&& uri) -> std::unique_ptr<MessageDispatcher> {
+    FLARE_NOT_IMPLEMENTED(
+        "No message dispatcher factory is provided for subsystem [{}], uri "
+        "[{}].",
+        subsys, uri);
+    return nullptr;
+  };
+  return &factory;
+}
+
+}  // namespace
+
+std::unique_ptr<MessageDispatcher> MakeMessageDispatcher(
+    std::string_view subsys, std::string_view uri) {
+  auto pos = uri.find_first_of("://");
+  FLARE_CHECK_NE(pos, std::string_view::npos, "No `scheme` found in URI [{}].",
+                 uri);
+  auto scheme = uri.substr(0, pos);
+  auto&& factories = *GetOrCreateFactoriesFor(subsys, scheme);
+  for (auto&& [_ /* priority */, e] : factories) {
+    if (auto ptr = e(uri)) {
+      return ptr;
+    }
+  }
+  return (*GetDefaultMessageDispatcherFactory())(subsys, uri);
+}
+
+void RegisterMessageDispatcherFactoryFor(
+    const std::string& subsys, const std::string& scheme, int priority,
+    Function<std::unique_ptr<MessageDispatcher>(std::string_view uri)>
+        factory) {
+  auto&& factories = GetOrCreateFactoriesFor(subsys, scheme);
+  factories->emplace_back(priority, std::move(factory));
+
+  // If multiple factories with the same priority present, we'd like to make
+  // sure the one added first is of higher priority.
+  std::stable_sort(factories->begin(), factories->end(),
+                   [](auto&& x, auto&& y) { return x.first < y.first; });
+}
+
+void SetDefaultMessageDispatcherFactory(
+    Function<std::unique_ptr<MessageDispatcher>(std::string_view subsys,
+                                                std::string_view uri)>
+        factory) {
+  *GetDefaultMessageDispatcherFactory() = std::move(factory);
+}
+
+std::unique_ptr<MessageDispatcher> MakeCompositedMessageDispatcher(
+    std::string_view resolver, std::string_view load_balancer) {
+  return std::make_unique<message_dispatcher::Composited>(
+      name_resolver_registry.Get(resolver),
+      load_balancer_registry.New(load_balancer));
+}
+
+}  // namespace flare

--- a/flare/rpc/message_dispatcher_factory.h
+++ b/flare/rpc/message_dispatcher_factory.h
@@ -1,0 +1,81 @@
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#ifndef FLARE_RPC_MESSAGE_DISPATCHER_FACTORY_H_
+#define FLARE_RPC_MESSAGE_DISPATCHER_FACTORY_H_
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "flare/base/function.h"
+#include "flare/base/internal/macro.h"
+#include "flare/rpc/message_dispatcher/message_dispatcher.h"
+
+namespace flare {
+
+// Create a new message dispatcher for subsystem `subsys`. `uri`, together with
+// `subsys`, is used to determine which NSLB should be used.
+//
+// `subsys` is defined by users (e.g., `RpcChannel`) of this method.
+//
+// It's still the caller's responsibility to call `Open` on the resulting
+// message dispatcher.
+std::unique_ptr<MessageDispatcher> MakeMessageDispatcher(
+    std::string_view subsys, std::string_view uri);
+
+// Register a factory for a given (`subsys`, `scheme` (of `uri` above))
+// combination.
+//
+// Factories with smaller `priority` take precedence. If `factory` does not
+// recognizes `uri` provided, it should return `nullptr`, and the factory with
+// the next lower priority is tried.
+//
+// This method may only be called upon startup.
+void RegisterMessageDispatcherFactoryFor(
+    const std::string& subsys, const std::string& scheme, int priority,
+    Function<std::unique_ptr<MessageDispatcher>(std::string_view uri)> factory);
+
+// This allows you to override default factory for `MakeMessageDispatcher`. The
+// default factory is use when no factory is registered for a given (`subsys`,
+// `scheme`) combination, or all factories registered returned `nullptr`.
+//
+// This method may only be called upon startup.
+void SetDefaultMessageDispatcherFactory(
+    Function<std::unique_ptr<MessageDispatcher>(std::string_view subsys,
+                                                std::string_view uri)>
+        factory);
+
+// Make a message dispatcher from the given name resolver and load balancer.
+// This method is provided to ease factory implementer's life.
+std::unique_ptr<MessageDispatcher> MakeCompositedMessageDispatcher(
+    std::string_view resolver, std::string_view load_balancer);
+
+}  // namespace flare
+
+// Register message dispatcher factory for the given `Subsystem` and `Scheme`.
+// Lower priority takes precedence.
+//
+// Multiple `Factory`-ies may be registered for the same scheme. If `Factory`
+// does not recognize `uri` given to it, `nullptr` should be returned. In this
+// case the next lower priority `Factory` is tried (and so on.).
+#define FLARE_RPC_REGISTER_MESSAGE_DISPATCHER_FACTORY_FOR(Subsystem, Scheme,  \
+                                                          Priority, Factory)  \
+  [[gnu::constructor]] static void FLARE_INTERNAL_PP_CAT(                     \
+      flare_reserved_registry_message_dispatcher_for_, __COUNTER__)() {       \
+    ::flare::RegisterMessageDispatcherFactoryFor(Subsystem, Scheme, Priority, \
+                                                 Factory);                    \
+  }
+
+#endif  // FLARE_RPC_MESSAGE_DISPATCHER_FACTORY_H_

--- a/flare/rpc/message_dispatcher_factory_test.cc
+++ b/flare/rpc/message_dispatcher_factory_test.cc
@@ -1,0 +1,146 @@
+// Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+//
+// Licensed under the BSD 3-Clause License (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+// https://opensource.org/licenses/BSD-3-Clause
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include "flare/rpc/message_dispatcher_factory.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "flare/base/string.h"
+#include "flare/rpc/load_balancer/load_balancer.h"
+#include "flare/rpc/name_resolver/name_resolver.h"
+
+namespace dummy {
+
+class DummyMessageDispatcher : public flare::MessageDispatcher {
+ public:
+  bool Open(const std::string& name) override { return true; }
+  bool GetPeer(std::uint64_t key, flare::Endpoint* addr,
+               std::uintptr_t* ctx) override {
+    return false;
+  }
+  void Report(const flare::Endpoint& addr, Status status,
+              std::chrono::nanoseconds time_cost, std::uintptr_t ctx) override {
+  }
+};
+
+class DummyMessageDispatcher2 : public flare::MessageDispatcher {
+ public:
+  bool Open(const std::string& name) override { return true; }
+  bool GetPeer(std::uint64_t key, flare::Endpoint* addr,
+               std::uintptr_t* ctx) override {
+    return false;
+  }
+  void Report(const flare::Endpoint& addr, Status status,
+              std::chrono::nanoseconds time_cost, std::uintptr_t ctx) override {
+  }
+};
+
+class DummyLoadBalancer : public flare::LoadBalancer {
+ public:
+  DummyLoadBalancer() { ++instances; }
+  void SetPeers(std::vector<flare::Endpoint> addresses) override {}
+  bool GetPeer(std::uint64_t key, flare::Endpoint* addr,
+               std::uintptr_t* ctx) override {
+    return false;
+  }
+  void Report(const flare::Endpoint& addr, Status status,
+              std::chrono::nanoseconds time_cost, std::uintptr_t ctx) {}
+
+  inline static int instances;
+};
+
+class DummyNameResolver : public flare::NameResolver {
+ public:
+  DummyNameResolver() { ++instances; }
+  std::unique_ptr<flare::NameResolutionView> StartResolving(
+      const std::string& name) override {
+    return nullptr;
+  }
+
+  inline static int instances;
+};
+
+}  // namespace dummy
+
+FLARE_RPC_REGISTER_LOAD_BALANCER("dummy", dummy::DummyLoadBalancer);
+FLARE_RPC_REGISTER_NAME_RESOLVER("dummy", dummy::DummyNameResolver);
+
+namespace flare {
+
+TEST(MessageDispatcherFactory, DefaultFactory) {
+  int x = 0;
+
+  SetDefaultMessageDispatcherFactory([&](auto&&...) {
+    x = 1;
+    return nullptr;
+  });
+  ASSERT_EQ(0, x);
+  MakeMessageDispatcher("something", "x://something else");
+  ASSERT_EQ(1, x);
+}
+
+TEST(MessageDispatcherFactory, PreinstalledFactory) {
+  SetDefaultMessageDispatcherFactory([&](auto&&...) { return nullptr; });
+
+  EXPECT_TRUE(dynamic_cast<dummy::DummyMessageDispatcher2*>(
+      MakeMessageDispatcher("boring-subsys", "scheme1://second:123").get()));
+  EXPECT_TRUE(dynamic_cast<dummy::DummyMessageDispatcher*>(
+      MakeMessageDispatcher("boring-subsys", "scheme1://first:123").get()));
+  EXPECT_TRUE(MakeMessageDispatcher("boring-subsys", "scheme2://first:123") ==
+              nullptr);
+}
+
+TEST(MessageDispatcherFactory, MakeComposited) {
+  auto ptr = MakeCompositedMessageDispatcher("dummy", "dummy");
+  EXPECT_EQ(1, dummy::DummyLoadBalancer::instances);
+  EXPECT_EQ(1, dummy::DummyNameResolver::instances);
+}
+
+}  // namespace flare
+
+FLARE_RPC_REGISTER_MESSAGE_DISPATCHER_FACTORY_FOR(
+    "boring-subsys", "scheme1", 0,
+    [](auto&& uri) -> std::unique_ptr<flare::MessageDispatcher> {
+      if (flare::StartsWith(uri, "scheme1://first:")) {
+        return std::make_unique<dummy::DummyMessageDispatcher>();
+      }
+      return nullptr;
+    });
+
+// Never used. It's added later than the factory above, and both handle prefix
+// `scheme1://first:`.
+FLARE_RPC_REGISTER_MESSAGE_DISPATCHER_FACTORY_FOR(
+    "boring-subsys", "scheme1", 0,
+    [](auto&& uri) -> std::unique_ptr<flare::MessageDispatcher> {
+      if (flare::StartsWith(uri, "scheme1://first:")) {
+        return std::make_unique<dummy::DummyMessageDispatcher2>();
+      }
+      return nullptr;
+    });
+
+FLARE_RPC_REGISTER_MESSAGE_DISPATCHER_FACTORY_FOR(
+    "boring-subsys", "scheme1",
+    0 /* Doesn't matter as it handles a different prefix. */,
+    [](auto&& uri) -> std::unique_ptr<flare::MessageDispatcher> {
+      if (flare::StartsWith(uri, "scheme1://second:")) {
+        return std::make_unique<dummy::DummyMessageDispatcher2>();
+      }
+      return nullptr;
+    });


### PR DESCRIPTION
Later we will use `MakeMessageDispatcher` in `RpcChannel` / `CosChannel` to move policies there out.