### PR TITLE
Not capturing fiber's execution context when setting a timer.

### DIFF
--- a/flare/fiber/BUILD
+++ b/flare/fiber/BUILD
@@ -216,7 +216,6 @@ cc_test(
   deps = [
     ':async',
     ':fiber',
-    ':timer',
     '//flare/testing:main',
   ]
 )

--- a/flare/fiber/execution_context_test.cc
+++ b/flare/fiber/execution_context_test.cc
@@ -77,26 +77,6 @@ TEST(ExecutionContext, AsyncPropagation) {
   });
 }
 
-TEST(ExecutionContext, TimerPropagation) {
-  ASSERT_EQ(nullptr, ExecutionContext::Current());
-  auto ctx = ExecutionContext::Create();
-  static ExecutionLocal<int> els_int;
-
-  ctx->Execute([&] {
-    *els_int = 10;
-    fiber::Latch latch(2);
-    SetDetachedTimer(ReadCoarseSteadyClock() + 100ms, [&] {
-      ASSERT_EQ(10, *els_int);
-      latch.count_down();
-    });
-    SetDetachedTimer(ReadCoarseSteadyClock() + 50ms, [&] {
-      ASSERT_EQ(10, *els_int);
-      latch.count_down();
-    });
-    latch.wait();
-  });
-}
-
 TEST(ExecutionLocal, All) {
   ASSERT_EQ(nullptr, ExecutionContext::Current());
   auto ctx = ExecutionContext::Create();


### PR DESCRIPTION
This was especially a horrible mistake for periodic timer. 

Because each RPC session is associated with an execution context, unless the timer is subsequently cancelled, the corresponding RPC session would never complete.