### PR TITLE
CTAD of std::tuple may implicitly convert pair<T, U> to tuple<T, U>, suppressing this behavior.

### DIFF
--- a/flare/fiber/fiber.h
+++ b/flare/fiber/fiber.h
@@ -108,11 +108,12 @@ class Fiber {
   template <class F, class... Args,
             class = std::enable_if_t<std::is_invocable_v<F&&, Args&&...>>>
   Fiber(const Attributes& attr, F&& f, Args&&... args)
-      : Fiber(attr, [f = std::forward<F>(f),
-                     // P0780R2 is not implemented as of now (GCC 8.2).
-                     t = std::tuple(std::forward<Args>(args)...)]() mutable {
-          std::apply(std::move(f), std::move(t));
-        }) {}
+      : Fiber(attr,
+              [f = std::forward<F>(f),
+               // P0780R2 is not implemented as of now (GCC 8.2).
+               t = std::make_tuple(std::forward<Args>(args)...)]() mutable {
+                std::apply(std::move(f), std::move(t));
+              }) {}
 
   // Special case if no parameter is passed to `F`, in this case we don't need
   // an indirection (the extra lambda).

--- a/flare/fiber/fiber_test.cc
+++ b/flare/fiber/fiber_test.cc
@@ -230,39 +230,33 @@ TEST(Fiber, StartFiberFromPthread) {
   });
 }
 
-
-void Product(int a, int b, int& c) {
-  c = a * b;
-}
+void Product(int a, int b, int& c) { c = a * b; }
 
 TEST(Fiber, CallWithArgs) {
-  RunAsFiber([](){
+  RunAsFiber([]() {
     // Test lambda
-    Fiber([](const char* hello) {
-      ASSERT_EQ(hello, "hello");
-    }, "hello").join();
+    Fiber([](const char* hello) { ASSERT_EQ(hello, "hello"); }, "hello").join();
 
-    Fiber([](auto&& First, auto&&... other){
-      auto ans = (First + ... + other);
-      ASSERT_EQ(ans, 55);
-    }, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10).join();
+    Fiber(
+        [](auto&& First, auto&&... other) {
+          auto ans = (First + ... + other);
+          ASSERT_EQ(ans, 55);
+        },
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        .join();
 
     // Test member method
     struct Add {
-      void operator()(int a, int b, int c) const {
-        ASSERT_EQ(a + b, c);
-      }
+      void operator()(int a, int b, int c) const { ASSERT_EQ(a + b, c); }
     };
 
     const Add add;
     Fiber(std::ref(add), 2, 3, 5).join();
     Fiber(&Add::operator(), &add, 1, 2, 3).join();
-    
-    struct Worker {   // Noncopyable
+
+    struct Worker {  // Noncopyable
       std::string s;
-      void work(std::string_view s) {
-        ASSERT_EQ("work...", s);
-      }
+      void work(std::string_view s) { ASSERT_EQ("work...", s); }
       void operator()(const std::string& str) { s = str; }
       Worker() = default;
       Worker(Worker&&) = default;
@@ -279,7 +273,8 @@ TEST(Fiber, CallWithArgs) {
     // Test template function
     std::vector vec{5, 4, 3, 2, 1};
     ASSERT_FALSE(std::is_sorted(vec.begin(), vec.end()));
-    Fiber(&std::sort<std::vector<int>::iterator>, vec.begin(), vec.end()).join();
+    Fiber(&std::sort<std::vector<int>::iterator>, vec.begin(), vec.end())
+        .join();
     ASSERT_TRUE(std::is_sorted(vec.begin(), vec.end()));
 
     // Test function name
@@ -292,9 +287,14 @@ TEST(Fiber, CallWithArgs) {
     ASSERT_EQ(res, 42);
 
     // Test bind
-    auto bind_function = std::bind(Product, 3, std::placeholders::_1, std::placeholders::_2);
+    auto bind_function =
+        std::bind(Product, 3, std::placeholders::_1, std::placeholders::_2);
     Fiber(bind_function, 5, std::ref(res)).join();
     ASSERT_EQ(res, 15);
+
+    // `std::pair` shouldn't be converted to `std::tuple` implicitly (by CTAD).
+    Fiber([&](auto&& p) { res = p.first; }, std::make_pair(1, 2)).join();
+    EXPECT_EQ(1, res);
   });
 }
 

--- a/flare/fiber/fiber_test.cc
+++ b/flare/fiber/fiber_test.cc
@@ -51,6 +51,9 @@ void RunAsFiber(F&& f) {
   fiber::TerminateRuntime();
 }
 
+// Passing `c` as non-const reference to test `std::ref` (see below.).
+void Product(int a, int b, int& c) { c = a * b; }
+
 }  // namespace
 
 TEST(Fiber, StartWithDispatch) {
@@ -229,8 +232,6 @@ TEST(Fiber, StartFiberFromPthread) {
     }
   });
 }
-
-void Product(int a, int b, int& c) { c = a * b; }
 
 TEST(Fiber, CallWithArgs) {
   RunAsFiber([]() {

--- a/flare/testing/detail/gmock_actions.h
+++ b/flare/testing/detail/gmock_actions.h
@@ -39,7 +39,7 @@ class ReturnImpl {
   using ValueTuple = std::tuple<Ts...>;
 
  public:
-  explicit ReturnImpl(Ts... value) : values_(std::tuple(std::move(value)...)) {}
+  explicit ReturnImpl(Ts... value) : values_(std::move(value)...) {}
 
   template <typename F>
   operator ::testing::Action<F>() const {


### PR DESCRIPTION
@sa: https://github.com/Tencent/flare/pull/66#issuecomment-1140406570, effectively reverting #73 .