### PR TITLE
fix(rpc): Use `std::monostate` exclusively to indicate that the messa…

### DIFF
--- a/flare/rpc/protocol/protobuf/message_test.cc
+++ b/flare/rpc/protocol/protobuf/message_test.cc
@@ -31,7 +31,7 @@ TEST(ErrorMessageFactory, CreateNormal) {
     auto msg = error_message_factory.Create(t, 123, false);
     auto pmsg = dyn_cast<ProtoMessage>(msg.get());
     ASSERT_TRUE(!!pmsg);
-    ASSERT_FALSE(!!std::get<1>(pmsg->msg_or_buffer));
+    ASSERT_EQ(0, pmsg->msg_or_buffer.index());
     ASSERT_EQ(rpc::METHOD_TYPE_SINGLE, pmsg->meta->method_type());
     ASSERT_EQ(123, pmsg->meta->correlation_id());
     ASSERT_EQ(s, pmsg->meta->response_meta().status());
@@ -43,7 +43,7 @@ TEST(ErrorMessageFactory, CreateStream) {
     auto msg = error_message_factory.Create(t, 123, true);
     auto pmsg = dyn_cast<ProtoMessage>(msg.get());
     ASSERT_TRUE(!!pmsg);
-    ASSERT_FALSE(!!std::get<1>(pmsg->msg_or_buffer));
+    ASSERT_EQ(0, pmsg->msg_or_buffer.index());
     ASSERT_EQ(rpc::METHOD_TYPE_STREAM, pmsg->meta->method_type());
     ASSERT_EQ(
         rpc::MESSAGE_FLAGS_START_OF_STREAM | rpc::MESSAGE_FLAGS_END_OF_STREAM,

--- a/flare/rpc/protocol/protobuf/proto_over_http_protocol_test.cc
+++ b/flare/rpc/protocol/protobuf/proto_over_http_protocol_test.cc
@@ -17,8 +17,8 @@
 #include <string>
 #include <unordered_map>
 
-#include "gtest/gtest.h"
 #include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
 
 #include "flare/base/down_cast.h"
 #include "flare/base/string.h"
@@ -175,7 +175,7 @@ TEST(ProtoOverHttpProtocol, PackFailureHttpResponseMessage) {
 
   ProtoOverHttpProtocol server_prot(
       ProtoOverHttpProtocol::ContentType::kApplicationJson, true);
-  ProtoMessage msg(std::move(src), nullptr);
+  ProtoMessage msg(std::move(src), std::monostate{});
   auto passive_ctx = server_prot.GetControllerFactory()->Create(false);
   NoncontiguousBuffer buffer;
   server_prot.WriteMessage(msg, &buffer, passive_ctx.get());

--- a/flare/rpc/protocol/protobuf/qzone_protocol.cc
+++ b/flare/rpc/protocol/protobuf/qzone_protocol.cc
@@ -258,8 +258,8 @@ bool QZoneProtocol::TryParse(std::unique_ptr<Message>* message,
             meta->correlation_id());
         return false;
       }
+      msg->msg_or_buffer = std::move(unpack_to);
     }
-    msg->msg_or_buffer = std::move(unpack_to);
   }
 
   msg->meta = std::move(meta);

--- a/flare/rpc/protocol/protobuf/rpc_controller_common_inl.h
+++ b/flare/rpc/protocol/protobuf/rpc_controller_common_inl.h
@@ -124,8 +124,8 @@ void TypedOutputStreamProvider<T>::WriteEosMarker(Function<void()> cb) {
 
   last_sent_ = true;
   ctlr_->output_stream_
-      ->WriteLast(
-          std::make_unique<protobuf::ProtoMessage>(std::move(meta), nullptr))
+      ->WriteLast(std::make_unique<protobuf::ProtoMessage>(std::move(meta),
+                                                           std::monostate{}))
       .Then([cb = std::move(cb)](bool) { cb(); });
 }
 

--- a/flare/rpc/protocol/protobuf/service.cc
+++ b/flare/rpc/protocol/protobuf/service.cc
@@ -64,7 +64,7 @@ ProtoMessage CreateErrorResponse(std::uint64_t correlation_id,
   meta->set_method_type(rpc::METHOD_TYPE_SINGLE);
   meta->mutable_response_meta()->set_status(status);
   meta->mutable_response_meta()->set_description(std::move(description));
-  return ProtoMessage(std::move(meta), nullptr);
+  return ProtoMessage(std::move(meta), std::monostate{});
 }
 
 std::unordered_map<std::string, std::uint32_t> ParseMaxOngoingRequestFlag() {
@@ -329,8 +329,8 @@ StreamService::ProcessingStatus Service::StreamCall(
     // In case the request is a single message, it should be passed to user's
     // code via `request` parameter. In this case passing it via `StreamReader`
     // is counter-intuitive.
-    FLARE_CHECK(
-        msg_ptr->msg_or_buffer.index() == 1,
+    FLARE_CHECK_EQ(
+        msg_ptr->msg_or_buffer.index(), 1,
         "Receiving request in bytes is not supported in streaming RPC.");
     request = std::get<1>(msg_ptr->msg_or_buffer).Get();
   }

--- a/flare/rpc/protocol/protobuf/service_test.cc
+++ b/flare/rpc/protocol/protobuf/service_test.cc
@@ -282,9 +282,10 @@ class ServiceTest : public ::testing::Test {
     svc->AddService(std::make_unique<ServiceImpl>());
 
     auto write_cb = [this](auto&& m) {
-      auto payload = std::get<1>(cast<ProtoMessage>(&m)->msg_or_buffer).Get();
-      if (payload) {
-        sctx->resps += flare::down_cast<testing::EchoResponse>(payload)->body();
+      auto&& msg = cast<ProtoMessage>(&m)->msg_or_buffer;
+      if (msg.index() != 0) {
+        auto&& p = std::get<1>(msg).Get();
+        sctx->resps += flare::down_cast<testing::EchoResponse>(p)->body();
       }
       sctx->sio_ptr->NotifyWriteCompletion();
       return true;


### PR DESCRIPTION
…ge body is empty.