### PR TITLE
Use XOR instead of ADD and SUB

### DIFF
--- a/flare/base/string.cc
+++ b/flare/base/string.cc
@@ -30,7 +30,7 @@ constexpr std::array<char, 256> kLowerChars = []() {
   std::array<char, 256> cs{};
   for (std::size_t index = 0; index != 256; ++index) {
     if (index >= 'A' && index <= 'Z') {
-      cs[index] = index - 'A' + 'a';
+      cs[index] = index ^ 32;
     } else {
       cs[index] = index;
     }
@@ -42,7 +42,7 @@ constexpr std::array<char, 256> kUpperChars = []() {
   std::array<char, 256> cs{};
   for (std::size_t index = 0; index != 256; ++index) {
     if (index >= 'a' && index <= 'z') {
-      cs[index] = index - 'a' + 'A';
+      cs[index] = index ^ 32;
     } else {
       cs[index] = index;
     }


### PR DESCRIPTION
根据`ASCII`码规则，
'A' = 01 **0** 00001 = 65
'a' = 01 **1** 00001 = 97
不难发现大小写字母二进制编码第`5`位(从`0`开始)不同，因此可以直接异或转换。
'A' ^ 32 = 'a'
'a' ^ 32 = 'A'