### PR TITLE
fix(LSP): no member named invoke in namespace std

### DIFF
--- a/flare/base/expected.h
+++ b/flare/base/expected.h
@@ -15,6 +15,7 @@
 #ifndef FLARE_BASE_EXPECTED_H_
 #define FLARE_BASE_EXPECTED_H_
 
+#include <functional>
 #include <initializer_list>
 #include <optional>
 #include <type_traits>


### PR DESCRIPTION
我把`flare/base/expected.h`相关文件单独拿出来，`LSP`提示`std::invoke`需要引入`#include <functional>`。