### PR TITLE
fix(bloom_filter): overflow bug

### DIFF
--- a/flare/base/experimental/bloom_filter.h
+++ b/flare/base/experimental/bloom_filter.h
@@ -287,7 +287,7 @@ std::uint64_t BloomFilter<HashGen>::GetOptimalBits(double p, std::uint64_t n,
 
 template <class HashGen>
 std::uint64_t BloomFilter<HashGen>::GetNextPowerOfTwo(std::uint64_t value) {
-  return value < 2 ? value : 1 << (64 - __builtin_clzl(value - 1));
+  return value < 2 ? value : 1ULL << (64 - __builtin_clzl(value - 1));
 }
 
 template <class HashGen>


### PR DESCRIPTION
遗漏了类型后缀`ULL`，当入参`value` > `0x40000000`，就会溢出。

为了减少内建函数依赖，也可以这么改：
```cpp
template <class HashGen>
std::uint64_t BloomFilter<HashGen>::GetNextPowerOfTwo(std::uint64_t value) {
  --value;
  value |= value >> 1;
  value |= value >> 2;
  value |= value >> 4;
  value |= value >> 8;
  value |= value >> 16;
  value |= value >> 32;
  return value + 1;
}
```