### PR TITLE
Add Fiber::get_id and use ExitBarrier's address as the fiber ID

### DIFF
--- a/flare/fiber/fiber.cc
+++ b/flare/fiber/fiber.cc
@@ -98,6 +98,10 @@ void Fiber::join() {
 
 bool Fiber::joinable() const { return !!join_impl_; }
 
+Fiber::Id Fiber::get_id() const noexcept {
+  return reinterpret_cast<Fiber::Id>(join_impl_.Get());
+}
+
 Fiber::Fiber(Fiber&&) noexcept = default;
 Fiber& Fiber::operator=(Fiber&&) noexcept = default;
 

--- a/flare/fiber/fiber.h
+++ b/flare/fiber/fiber.h
@@ -15,6 +15,7 @@
 #ifndef FLARE_FIBER_FIBER_H_
 #define FLARE_FIBER_FIBER_H_
 
+#include <cstdint>
 #include <limits>
 #include <utility>
 #include <vector>
@@ -53,7 +54,7 @@ class Fiber {
   static constexpr auto kUnspecifiedSchedulingGroup =
       std::numeric_limits<std::size_t>::max();
 
-  using Id = struct InternalOpaqueId*;
+  using Id = std::uintptr_t;
 
   struct Attributes {
     // How the fiber is launched.
@@ -135,6 +136,8 @@ class Fiber {
 
   // Test if we can call `join()` on this object.
   bool joinable() const;
+
+  Id get_id() const noexcept;
 
   // Movable but not copyable
   Fiber(Fiber&&) noexcept;

--- a/flare/fiber/this_fiber.cc
+++ b/flare/fiber/this_fiber.cc
@@ -24,7 +24,7 @@ Fiber::Id GetId() {
   auto self = fiber::detail::GetCurrentFiberEntity();
   FLARE_CHECK(self,
               "this_fiber::GetId may only be called in fiber environment.");
-  return reinterpret_cast<Fiber::Id>(self);
+  return reinterpret_cast<Fiber::Id>(self->exit_barrier.Get());
 }
 
 void Yield() {


### PR DESCRIPTION
Similar to `std::thread`, Fiber should also have a `get_id` method.