### PR TITLE
Resolve the two long-standing Missing-dependency notices

### DIFF
--- a/flare/base/exposed_var_test.cc
+++ b/flare/base/exposed_var_test.cc
@@ -17,7 +17,6 @@
 #include "gtest/gtest.h"
 #include "jsoncpp/json.h"
 
-#include "flare/base/write_mostly/metrics.h"
 #include "flare/testing/main.h"
 
 namespace flare {

--- a/flare/rpc/BUILD
+++ b/flare/rpc/BUILD
@@ -35,6 +35,12 @@ cc_library(
     # Frequently used protocols.
     '//flare/rpc/protocol/http:http',
     '//flare/rpc/protocol/protobuf:protobuf',
+    # `http_filter.h` / `http_handler.h` (this target's own hdrs) re-export
+    # these protocol-layer types; depend on the owning libs directly so
+    # blade's Missing-dep check is satisfied. Both libs treat us as a
+    # `friend` via their visibility list.
+    '//flare/rpc/protocol/http:http_filter',
+    '//flare/rpc/protocol/http:http_handler',
     '//flare/base/internal:test_prod',
     '//flare/base/net:endpoint',
     '//flare/base:down_cast',

--- a/flare/rpc/protocol/http/BUILD
+++ b/flare/rpc/protocol/http/BUILD
@@ -28,7 +28,11 @@ cc_library(
     '//flare/net/http:http_request',
     '//flare/net/http:http_response',
   ],
-  visibility = '//flare/rpc:http',
+  # Treated like a C++ `friend` declaration: only the two umbrella facades
+  # may BUILD-depend on this lib directly. `//flare/rpc:http` (inner) is the
+  # canonical re-exporter, and `//flare/rpc:rpc` (outer) re-includes through
+  # its own `http_filter.h`. Anyone else must go through one of those.
+  visibility = ['//flare/rpc:http', '//flare/rpc:rpc'],
 )
 
 cc_library(
@@ -44,7 +48,8 @@ cc_library(
     '//flare/net/http:http_request',
     '//flare/net/http:http_response',
   ],
-  visibility = '//flare/rpc:http',
+  # See `:http_filter` above -- same `friend`-list scoping.
+  visibility = ['//flare/rpc:http', '//flare/rpc:rpc'],
 )
 
 cc_library(


### PR DESCRIPTION
## Summary

`blade build --cc-check-undefined flare/...` has been emitting two `Missing dependency` notices since PR #159 -- left in place at the time as known visibility-blocked cases. Looking again, they turn out to be two **distinct** patterns, each fixable without exposing internals.

| Notice | Pattern | Fix |
|---|---|---|
| `flare/base:exposed_var_test` -> `//flare/base/write_mostly:metrics` | The `#include \"flare/base/write_mostly/metrics.h\"` line is a **dead include**. The test only uses `ExposedMetrics<T>` (defined in `flare/base/exposed_var.h`, already included). It never names anything from `metrics.h`. | Delete the `#include` line. No dep change. The private `:metrics` lib stays encapsulated. |
| `flare/rpc:rpc` -> `//flare/rpc/protocol/http:http_{filter,handler}` | `flare/rpc/http_filter.h` / `http_handler.h` (rpc:rpc's public hdrs) re-`#include` the corresponding `protocol/http/*.h` so consumers of the outer facade get the types. The protocol-layer libs had `visibility = '//flare/rpc:http'`, blocking rpc:rpc even though it's the canonical re-exporter. | Widen visibility to `['//flare/rpc:http', '//flare/rpc:rpc']` (C++ `friend`-style allow-list -- still not PUBLIC; both facade targets only) and declare the deps explicitly on the umbrella's side. |

After this: `blade build --cc-check-undefined flare/...` -> 0 Missing-dep notices, 0 Unused-dep notices.

## Why not just \"add the dep\"?

For case 1, following blade's mechanical suggestion (\"add `:metrics` to deps\") would bloat the dep graph with a library the test doesn't actually use, **and** would expose `:metrics`'s internal transitive deps (spinlock, time_keeper, chrono, ...) to a target that should be self-contained. Deleting the include is the architecturally correct fix.

For case 2, the same suggestion runs straight into a `visibility` error on the next build, because `:http_filter` / `:http_handler` were locked to the inner `:http` facade. The relationship is legitimate (rpc:rpc IS the outer re-exporter), so the right move is to acknowledge the relationship in visibility, not to keep emitting a notice forever or restructure the source code unnecessarily.

The corresponding blade-build docs PR (https://github.com/blade-build/blade-build/pull/1237) writes both patterns up as cases 6 and 7 under \"Fix missing dependencies errors caused by `hdrs`\", with the flare fix as the worked example.

## Test plan

- [x] `blade build --cc-check-undefined flare/...` -> 0 notices.
- [x] `blade test //flare/base:exposed_var_test` passes (the deleted include was unused; behavior unchanged).
- [ ] Full test suite green on CI (blocking merge until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)