### PR TITLE
ci: cache bazel output + blade build64_release across runs

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -13,6 +13,22 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    # Cache bazel's output base. Restoring it makes a "warm" CI run reuse
+    # everything bazel already compiled (foreign_cc thirdparty, all .o, test
+    # results) -- the next push that touches only a few .cc files rebuilds
+    # those plus their downstream, instead of the full ~14 min cold build.
+    # Key is tied to WORKSPACE + every BUILD.bazel + thirdparty tarballs so
+    # any structural change invalidates; restore-keys lets us fall back to
+    # the most recent cache on the same OS even if those don't match.
+    - name: Cache bazel
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/bazel
+        key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD.bazel', 'thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/*.patch') }}
+        restore-keys: |
+          bazel-${{ runner.os }}-
+
     - name: Setup bazel
       run: |
         rm -rf /usr/local/bin/bazel
@@ -36,6 +52,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+
+    - name: Cache bazel
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/bazel
+        key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD.bazel', 'thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/*.patch') }}
+        restore-keys: |
+          bazel-${{ runner.os }}-
 
     # foreign_cc autotools deps (jemalloc/openssl/curl/nghttp2) run autogen.sh,
     # which needs autoconf/automake/libtool (not preinstalled on the runner).

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,20 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-${{ matrix.cc }} g++-${{ matrix.cc }} ninja-build
+    # Cache blade's build dir. The thirdparty/ subtree is the big win
+    # (foreign_cc curl/openssl/jemalloc/nghttp2 each take minutes to build);
+    # the rest of build64_release/ also caches per-target .o so unchanged
+    # cc_libraries don't recompile. Key is per-(OS,gcc) since binaries are
+    # not portable; hashed inputs cover the thirdparty source archives so
+    # any upstream bump invalidates.
+    - name: Cache blade build dir
+      uses: actions/cache@v4
+      with:
+        path: |
+          build64_release
+        key: blade-${{ runner.os }}-${{ matrix.cc }}-${{ hashFiles('thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/BUILD', 'thirdparty/**/*.patch') }}
+        restore-keys: |
+          blade-${{ runner.os }}-${{ matrix.cc }}-
     - name: Build
       run: |
         CC=gcc-${{ matrix.cc }} CXX=g++-${{ matrix.cc }} ./blade build ... -k
@@ -61,6 +75,14 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-${{ matrix.cc }} g++-${{ matrix.cc }} ninja-build
+    - name: Cache blade build dir
+      uses: actions/cache@v4
+      with:
+        path: |
+          build64_release
+        key: blade-${{ runner.os }}-${{ matrix.cc }}-${{ hashFiles('thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/BUILD', 'thirdparty/**/*.patch') }}
+        restore-keys: |
+          blade-${{ runner.os }}-${{ matrix.cc }}-
     - name: Build
       run: |
         CC=gcc-${{ matrix.cc }} CXX=g++-${{ matrix.cc }} ./blade build ... -k
@@ -75,6 +97,14 @@ jobs:
     - uses: actions/checkout@v6
       with:
         lfs: true
+    - name: Cache blade build dir
+      uses: actions/cache@v4
+      with:
+        path: |
+          build64_release
+        key: blade-${{ runner.os }}-${{ hashFiles('thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/BUILD', 'thirdparty/**/*.patch') }}
+        restore-keys: |
+          blade-${{ runner.os }}-
     # blade uses the system cmake/ninja on macOS (cmake is preinstalled on the
     # runner; ninja is not). autoconf/automake/libtool are needed by autotools-
     # based thirdparty packages (e.g. jemalloc's autogen.sh).


### PR DESCRIPTION
## Summary

Both bazel and blade CI workflows currently start from scratch on every push. Big wastes:

* foreign_cc thirdparty libs (curl/openssl/jemalloc/nghttp2) each take minutes to build
* All `.cc` files recompile even when the PR only touches a few

Add `actions/cache@v4` to both workflows:

| Workflow | Path cached | Key |
|---|---|---|
| `bazel-build.yml` | `~/.cache/bazel` | per OS, hashed over WORKSPACE / BUILD.bazel / thirdparty src |
| `build-and-test.yml` | `build64_release/` | per (OS, gcc), hashed over thirdparty src / BUILD / patches |

`restore-keys` falls back to the most recent same-OS cache on miss so non-master branches still benefit from master's cache.

## Estimated effect

| Scenario | Now | With cache |
|---|---|---|
| Cold cache (first run, infrequent) | ~24 min | ~24 min |
| Typical PR changing a few `.cc` | ~24 min | **~5-10 min** |
| README/doc-only PR | ~24 min | **~2-5 min** |
| thirdparty bump | ~24 min | ~22 min (foreign_cc cache invalidated, rest hits) |

## Caveats

* GHA cache is capped at **10 GB/repo**; older keys evicted LRU. With 3-4 OS × compiler combinations plus both bazel and blade entries, we may approach the ceiling -- worth watching for thrash in early days.
* **PRs only read the base-branch (master) cache** — cross-PR sharing doesn't happen, so the first run on a PR branch is the "cold" one and subsequent push to the same branch benefits.

## Test plan

- [ ] First CI run on this branch: expect ~24 min (cold cache)
- [ ] Push trivial commit to this branch after first run completes: expect <10 min on bazel job (cache restored)
- [ ] Verify cache stays under 10 GB via repo Actions cache page

🤖 Generated with [Claude Code](https://claude.com/claude-code)