### PR TITLE
test: shrink over-scaled loops in run_queue / waitable / fiber tests

### DIFF
--- a/flare/fiber/detail/run_queue_test.cc
+++ b/flare/fiber/detail/run_queue_test.cc
@@ -55,14 +55,14 @@ TEST(RunQueue, Nonstealable) {
 }
 
 TEST(RunQueue, Torture) {
-  constexpr auto N = 1'000'000;
+  constexpr auto N = 200'000;
 
   RunQueue queue(1048576);
 
   // Loop for several rounds so that we can test the case when queue's internal
   // ring buffer wraps around.
-  for (int k = 0; k != 10; ++k) {
-    constexpr auto T = 200;
+  for (int k = 0; k != 3; ++k) {
+    constexpr auto T = 100;
     std::thread ts[T];
     Latch latch(T);
     std::mutex lock;
@@ -122,12 +122,12 @@ TEST(RunQueue, Torture) {
 }
 
 TEST(RunQueue, Overrun) {
-  constexpr auto T = 40;
-  constexpr auto N = 100'000;
+  constexpr auto T = 20;
+  constexpr auto N = 20'000;
 
   // Loop for several rounds so that we can test the case when queue's internal
   // ring buffer wraps around.
-  for (int k = 0; k != 10; ++k) {
+  for (int k = 0; k != 3; ++k) {
     RunQueue queue(8192);
     std::atomic<std::size_t> overruns{};
     std::atomic<std::size_t> popped{};
@@ -181,14 +181,14 @@ TEST(RunQueue, Overrun) {
 }
 
 TEST(RunQueue, Throughput) {
-  constexpr auto N = 1'000'000;
+  constexpr auto N = 200'000;
 
   RunQueue queue(1048576);
 
   // Loop for several rounds so that we can test the case when queue's internal
   // ring buffer wraps around.
-  for (int k = 0; k != 10; ++k) {
-    constexpr auto T = 200;
+  for (int k = 0; k != 3; ++k) {
+    constexpr auto T = 100;
     std::thread ts[T];
     Latch latch(T), latch2(T);
     std::mutex lock;

--- a/flare/fiber/detail/waitable_test.cc
+++ b/flare/fiber/detail/waitable_test.cc
@@ -107,9 +107,9 @@ TEST_P(SystemFiberOrNot, Mutex) {
 }
 
 TEST_P(SystemFiberOrNot, ConditionVariable) {
-  constexpr auto N = 10000;
+  constexpr auto N = 2000;
 
-  for (int i = 0; i != 10; ++i) {
+  for (int i = 0; i != 3; ++i) {
     Mutex m[N];
     ConditionVariable cv[N];
     std::queue<int> queue[N];
@@ -163,7 +163,7 @@ TEST_P(SystemFiberOrNot, ConditionVariable) {
 TEST_P(SystemFiberOrNot, ConditionVariable2) {
   constexpr auto N = 1000;
 
-  for (int i = 0; i != 50; ++i) {
+  for (int i = 0; i != 10; ++i) {
     Mutex m[N];
     ConditionVariable cv[N];
     bool f[N] = {};
@@ -258,9 +258,9 @@ TEST_P(SystemFiberOrNot, ConditionVariableRace) {
 }
 
 TEST_P(SystemFiberOrNot, ExitBarrier) {
-  constexpr auto N = 10000;
+  constexpr auto N = 2000;
 
-  for (int i = 0; i != 10; ++i) {
+  for (int i = 0; i != 3; ++i) {
     std::deque<ExitBarrier> l;
     std::atomic<std::size_t> waited{};
 
@@ -288,9 +288,9 @@ TEST_P(SystemFiberOrNot, ExitBarrier) {
 }
 
 TEST_P(SystemFiberOrNot, Event) {
-  constexpr auto N = 10000;
+  constexpr auto N = 2000;
 
-  for (int i = 0; i != 10; ++i) {
+  for (int i = 0; i != 3; ++i) {
     std::deque<Event> evs;
     std::atomic<std::size_t> waited{};
 
@@ -338,10 +338,10 @@ TEST_P(SystemFiberOrNot, OneshotTimedEvent) {
 }
 
 TEST_P(SystemFiberOrNot, OneshotTimedEventTorture) {
-  constexpr auto N = 10000;
+  constexpr auto N = 2000;
 
   RunInFiber(1, GetParam(), [&](auto) {
-    for (int i = 0; i != 10; ++i) {
+    for (int i = 0; i != 3; ++i) {
       std::deque<OneshotTimedEvent> evs;
       std::atomic<std::size_t> waited{};
 

--- a/flare/fiber/fiber_test.cc
+++ b/flare/fiber/fiber_test.cc
@@ -118,9 +118,9 @@ TEST(Fiber, SchedulingGroupLocal) {
 
     auto start = ReadSteadyClock();
 
-    // 10s should be far from enough. In my test the assertion above fires
+    // 3s should be far from enough. In my test the assertion above fires
     // almost immediately if `scheduling_group_local` is not set.
-    while (start + 10s > ReadSteadyClock()) {
+    while (start + 3s > ReadSteadyClock()) {
       std::this_thread::sleep_for(1ms);
 
       // Wake up workers in each scheduling group (for them to be thieves.).


### PR DESCRIPTION
## Summary

Themed PR: shrink over-scaled stress loops in a few hot tests. Follow-up to #163.

Local arm64 (release/-O2) before → after:

| Test | Before | After | Speedup |
|---|---|---|---|
| `flare/fiber/detail:run_queue_test` | 81.9s | **5.4s** | **15x** |
| `flare/fiber/detail:waitable_test` | 43.7s | **24.1s** | 1.8x |
| `flare/fiber:fiber_test` | 13.9s | **7.5s** | 1.85x |
| **Sum (sequential)** | **139.5s** | **37.0s** | **3.8x** |

CI Linux is ~3x slower → estimated ~30s wall after 10-way test parallelism.

## Per-case detail

### run_queue_test
- Torture: N=1M × T=200 × k=10 → N=200K × T=100 × k=3 (still 60M ops)
- Overrun: N=100K × T=40 × k=10 → N=20K × T=20 × k=3 (still hammers overrun path)
- Throughput: N=1M × T=200 × k=10 → N=200K × T=100 × k=3 (still measures throughput)

### waitable_test
5 of 12 TEST_P cases reduced (others already small or sleep-bound):
- ConditionVariable: N=10K × outer=10 → N=2K × outer=3
- ConditionVariable2: outer=50 → outer=10
- ExitBarrier: N=10K × outer=10 → N=2K × outer=3
- Event: N=10K × outer=10 → N=2K × outer=3
- OneshotTimedEventTorture: N=10K × outer=10 → N=2K × outer=3

### fiber_test
SchedulingGroupLocal had hardcoded \`while (start + 10s > ...)\` busy-wait. Comment said "10s should be far from enough" — 3s preserves both intent and safety margin.

## Why not more

Top-N "slow" list also contained \`override_rlimit_test\` (66s), \`buffer_io_test\` (44s), \`rpc_mock_test\` (48s), etc. Direct runs show they take **<1s** in isolation — the "slow" reading is concurrency-contention artifact from parallel test scheduling, not real test cost. Reducing those wouldn't help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)