### PR TITLE
test: mark CPU-heavy tests exclusive for scheduling stability

### DIFF
--- a/flare/base/BUILD
+++ b/flare/base/BUILD
@@ -75,7 +75,8 @@ cc_test(
     ':random',
     ':string',
     '//flare/testing:main',
-  ]
+  ],
+  exclusive = True,
 )
 
 cc_benchmark(
@@ -652,6 +653,7 @@ cc_test(
   ],
   # Heap checker is rather slow that we'd timeout if it's enabled.
   heap_check = '',
+  exclusive = True,
 )
 
 cc_test(

--- a/flare/base/internal/BUILD
+++ b/flare/base/internal/BUILD
@@ -95,7 +95,8 @@ cc_test(
     '//flare/base:write_mostly',
     '//flare/fiber:fiber',
     '//flare/testing:main',
-  ]
+  ],
+  exclusive = True,
 )
 
 cc_benchmark(

--- a/flare/base/object_pool/BUILD
+++ b/flare/base/object_pool/BUILD
@@ -115,7 +115,8 @@ cc_test(
     '//flare/base:object_pool',
     '//flare/base/thread:latch',
     '//flare/base:random',
-  ]
+  ],
+  exclusive = True,
 )
 
 cc_benchmark(

--- a/flare/fiber/detail/BUILD
+++ b/flare/fiber/detail/BUILD
@@ -187,7 +187,8 @@ cc_test(
     '//flare/fiber/detail:testing',
     '//flare/base:chrono',
     '//flare/base:tsc',
-  ]
+  ],
+  exclusive = True,
 )
 
 cc_library(


### PR DESCRIPTION
## Summary

Mark 5 CPU-heavy tests `exclusive = True` so they run serially after the parallel pool, rather than oversubscribing the box and starving neighbours of CPU.

| Test | Standalone CPU% |
|---|---|
| `flare/base/object_pool:memory_node_shared_test` | 811% |
| `flare/base/internal:dpc_test` | 576% |
| `flare/base:monitoring_test` | 554% |
| `flare/fiber/detail:waitable_test` | 331% |
| `flare/base:hazptr_test` | 321% |

(measured on M2, release/-O2, blade test --full-test)

## Why this, not loop reduction

The point is **scheduling stability**, not wall time. When these tests run in the parallel pool, they each want 3-8 cores; together they saturate the box and starve timing-sensitive neighbours, producing CI flakes that don't reproduce locally.

This extends an existing pattern: `chrono_test`, `time_keeper_test`, `time_view_test`, `timer_test`, `this_fiber_test`, `scheduling_group_test`, and `dumper_test` are already marked `exclusive` for the same reason (timing accuracy under contention).

## Wall-time impact

Local M2 8-core: 2m44 → 4m30 (+106s). The pool was already CPU-saturated, so moving these out doesn't free up much for phase 1 and adds the serial sum to phase 2.

**CI is the actual question.** GHA standard runners are 2-core: the oversubscription pain was worse there, so phase-1 savings should be larger relative to the serial cost. Measuring on this PR's CI is the point — if Run tests regresses, we'll scope back to top-2 (`memory_node_shared_test` + `dpc_test`, the >550% CPU pair).

## Test plan

- [x] All 235 tests pass after change (local M2)
- [ ] CI Run tests duration: compare to master baseline (8:31 / 8:09 on ubuntu_22/24)
- [ ] If CI also regresses meaningfully, scope down to top-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)