### PR TITLE
ci: use ccache to make incremental CI builds actually incremental

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,13 +33,18 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-${{ matrix.cc }} g++-${{ matrix.cc }} ninja-build
-    # Cache blade's build dir. The thirdparty/ subtree is the big win
-    # (foreign_cc curl/openssl/jemalloc/nghttp2 each take minutes to build);
-    # the rest of build64_release/ also caches per-target .o so unchanged
-    # cc_libraries don't recompile. Key is per-(OS,gcc) since binaries are
-    # not portable; hashed inputs cover the thirdparty source archives so
-    # any upstream bump invalidates.
+        sudo apt-get install -y gcc-${{ matrix.cc }} g++-${{ matrix.cc }} ninja-build ccache
+        # /usr/lib/ccache holds symlinks (gcc, g++, gcc-10, ...) -> ccache.
+        # Prepending to PATH makes blade's shutil.which('gcc') resolve to the
+        # ccache shim; ccache then dispatches to the real compiler via its
+        # own PATH inspection. Blade reads no env var here.
+        echo "/usr/lib/ccache" >> $GITHUB_PATH
+    # build64_release cache covers thirdparty/foreign_cc artifacts (curl/openssl/
+    # jemalloc/nghttp2 etc.); those are autotools/cmake subbuilds, not plain
+    # cc_libraries, so ccache can't help with them. The .o files inside
+    # build64_release/ rarely survive an incremental run because actions/checkout
+    # resets source mtimes -- that's precisely what ccache (content-hash based)
+    # solves for the regular cc_library/cc_test compilations.
     - name: Cache blade build dir
       uses: actions/cache@v4
       with:
@@ -48,9 +53,20 @@ jobs:
         key: blade-${{ runner.os }}-${{ matrix.cc }}-${{ hashFiles('thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/BUILD', 'thirdparty/**/*.patch') }}
         restore-keys: |
           blade-${{ runner.os }}-${{ matrix.cc }}-
+    - name: Cache ccache db
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ runner.os }}-${{ matrix.cc }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ runner.os }}-${{ matrix.cc }}-
+    - name: ccache stats (before)
+      run: ccache --zero-stats && ccache --show-config
     - name: Build
       run: |
         CC=gcc-${{ matrix.cc }} CXX=g++-${{ matrix.cc }} ./blade build ... -k
+    - name: ccache stats (after)
+      run: ccache --show-stats
     - name: Run tests
       run: |
         CC=gcc-${{ matrix.cc }} CXX=g++-${{ matrix.cc }} ./blade test ...
@@ -74,7 +90,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y gcc-${{ matrix.cc }} g++-${{ matrix.cc }} ninja-build
+        sudo apt-get install -y gcc-${{ matrix.cc }} g++-${{ matrix.cc }} ninja-build ccache
+        echo "/usr/lib/ccache" >> $GITHUB_PATH
     - name: Cache blade build dir
       uses: actions/cache@v4
       with:
@@ -83,9 +100,20 @@ jobs:
         key: blade-${{ runner.os }}-${{ matrix.cc }}-${{ hashFiles('thirdparty/**/*.tar.gz', 'thirdparty/**/*.zip', 'thirdparty/**/BUILD', 'thirdparty/**/*.patch') }}
         restore-keys: |
           blade-${{ runner.os }}-${{ matrix.cc }}-
+    - name: Cache ccache db
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ runner.os }}-${{ matrix.cc }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ runner.os }}-${{ matrix.cc }}-
+    - name: ccache stats (before)
+      run: ccache --zero-stats && ccache --show-config
     - name: Build
       run: |
         CC=gcc-${{ matrix.cc }} CXX=g++-${{ matrix.cc }} ./blade build ... -k
+    - name: ccache stats (after)
+      run: ccache --show-stats
     - name: Run tests
       run: |
         CC=gcc-${{ matrix.cc }} CXX=g++-${{ matrix.cc }} ./blade test ...
@@ -109,6 +137,21 @@ jobs:
     # runner; ninja is not). autoconf/automake/libtool are needed by autotools-
     # based thirdparty packages (e.g. jemalloc's autogen.sh).
     - name: Install dependencies
-      run: brew install ninja autoconf automake libtool
+      run: |
+        brew install ninja autoconf automake libtool ccache
+        # brew's ccache pkg installs symlinks (gcc, g++, clang, ...) into
+        # $(brew --prefix)/opt/ccache/libexec. Same trick as Linux.
+        echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
+    - name: Cache ccache db
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/ccache
+        key: ccache-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ runner.os }}-
+    - name: ccache stats (before)
+      run: ccache --zero-stats && ccache --show-config
     - name: Build
       run: ./blade build flare/... -k
+    - name: ccache stats (after)
+      run: ccache --show-stats


### PR DESCRIPTION
## Summary

PR #164 added `actions/cache` for `build64_release/`, but incremental CI builds still run nearly cold — ninja starts at `[1/2956]` (1161 CXX + 419 CC actions) each time. Cache HIT happens, but `actions/checkout` resets all source mtimes to "now", which is newer than the cached `.o` files → ninja decides everything changed → recompile everything.

ccache fixes this with **content-based hashing**, ignoring mtime entirely.

## How it hooks in

Pure PATH-injection — no blade changes needed:

```yaml
sudo apt-get install -y ... ccache
echo "/usr/lib/ccache" >> $GITHUB_PATH
```

`/usr/lib/ccache/` (from Ubuntu's `ccache` package) contains symlinks `gcc → ccache`, `g++ → ccache`, `gcc-10 → ccache`, etc. With that dir prepended to PATH, blade's `shutil.which('gcc')` resolves to the ccache shim transparently. ccache dispatches to the real compiler via its own PATH inspection.

(Blade doesn't read `CC` env var — confirmed by reading toolchain.py:399 + verified by build log showing ubuntu_22 actually compiles with gcc-11 despite `CC=gcc-10` in the workflow. That's a separate matrix-correctness issue; tracked elsewhere.)

## Caches are complementary

- `build64_release/` cache (from #164): keeps `thirdparty/foreign_cc` subbuild artifacts (curl/openssl/jemalloc/nghttp2). ccache can't help here — autotools/cmake produce many compile+link invocations that ccache handles individually but the foreign_cc driver itself is the slow part.
- `~/.cache/ccache` (this PR): the regular `cc_library` / `cc_test` compilations — where mtime invalidation was hurting most.

## Expected effect

Master baseline (cold cache):

| | Build | Run tests | Total |
|---|---|---|---|
| ubuntu_22 (gcc-10) | 14:54 | 7:46 | 23m |
| ubuntu_24 (gcc-13) | 17:50 | 7:40 | 26m |
| macos | 14:18 | (no test) | 15m |

After ccache lands, on a typical PR (master cache hit, few `.cc` changes):

| | Build (expected) | Note |
|---|---|---|
| ubuntu_22 | ~3-5 min | only changed .cc recompile |
| ubuntu_24 | ~3-5 min | same |
| macos | ~3-5 min | same |

Cold cache (e.g. thirdparty bump): unchanged from current.

## Validation

The two `ccache --show-stats` steps print hit/miss counts. First run after this lands = miss only (no prior ccache db). Subsequent PRs should show high hit rate.

## Test plan

- [ ] PR's own CI: first run = ccache miss expected; full populate
- [ ] Second push to this branch: should see big hit ratio + Build step shrink dramatically
- [ ] If hit ratio < 80% on routine PRs, tune `CCACHE_BASEDIR`, `CCACHE_COMPILERCHECK`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)