### PR TITLE
ci: skip heavy workflows on markdown-only changes

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -1,10 +1,17 @@
 name: Bazel Build
 
 on:
+  # Skip when every changed file is markdown. See the matching note in
+  # build-and-test.yml; the markdown-link-check workflow still runs and
+  # verifies documentation correctness independently.
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,10 +1,18 @@
 name: Build and Test
 
 on:
+  # Skip when every changed file is markdown (README / docs / etc.). The
+  # workflow still fires if a PR touches even one non-markdown file in
+  # addition to docs. The markdown-link-check workflow keeps running on
+  # all changes -- documentation correctness still gets verified.
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   # Oldest supported compiler (gcc 11, first libstdc++ with std::atomic

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,10 +1,16 @@
 name: clang-format Check
 
-on: 
+on:
+  # clang-format only inspects C/C++/Protobuf sources under flare/; skip
+  # for pure-markdown changes.
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   formatting-check:


### PR DESCRIPTION
## Summary

Adds `paths-ignore: ['**/*.md']` to the push / pull_request triggers of:

- `build-and-test.yml` (blade build + test, longest job at ~25 min)
- `bazel-build.yml` (bazel build + test, second-longest at ~15 min)
- `clang-format-check.yml` (inspects C/C++/Protobuf sources only)

`check-md-links.yml` is untouched — it's the workflow that actually verifies markdown.

## Semantics

GitHub Actions skips the workflow only when **every** changed file matches the ignore pattern. So:

| PR changes | Build runs? | Tests run? | markdown-link-check runs? |
|---|---|---|---|
| Only `*.md` | ❌ skipped | ❌ skipped | ✅ |
| `*.md` + `*.cc` | ✅ | ✅ | ✅ |
| Only `*.cc` | ✅ | ✅ | ❌ (no .md changed)* |

\* `check-md-links.yml` doesn't have its own paths filter so it does still trigger on code-only PRs; harmless because the action only scans .md files. Could add a symmetric `paths: ['**/*.md']` to make it only run on doc changes, but that's a separate optimization and not the user's ask here.

## Expected wins

- Pure docs/README PRs (like the recent README rewrite PR #172) avoid ~25 minutes of build + test work.
- Documentation correctness still verified end-to-end by `markdown-link-check`.

## Test plan

- [x] This PR itself touches non-md files (workflow yml) → build + test should still fire to prove the predicate is right
- [ ] A follow-up md-only PR should show only markdown-link-check running

🤖 Generated with [Claude Code](https://claude.com/claude-code)