### PR TITLE
thirdparty/gtest: build both static and shared libs to fix empty test registries on macOS

### DIFF
--- a/thirdparty/foreign_build.bld
+++ b/thirdparty/foreign_build.bld
@@ -326,6 +326,7 @@ def cmake_build(name,
                 strip_include_prefix='',
                 cmake_options=None,
                 generate_dynamic=False,
+                shared_cmake_options=None,
                 patches=[]):
     source_dir = source_dir or _get_package_name(source_package)
     lib_names = lib_names or [package_name]
@@ -349,17 +350,37 @@ def cmake_build(name,
     full_install_dir = blade.path.join(blade.current_target_dir(), install_dir)
     strip_include_dir = blade.path.normpath(
         blade.path.join(include_dir, strip_include_prefix))
-    cmds = [
-        _cmd_with_log(build_cmd, log_file),
-        _EXPORT_HEADERS.format(install_dir=full_install_dir,
-                               include_dir=strip_include_dir),
-    ]
+    src_files = [build_file]
+    generate_deps = [':' + target_generate]
+    cmds = [_cmd_with_log(build_cmd, log_file)]
+    # Packages whose CMake can only emit static *or* shared in a single
+    # configure (e.g. googletest, which keys solely off BUILD_SHARED_LIBS)
+    # need a second pass to produce both. `shared_cmake_options` triggers an
+    # extra configure+install into the SAME prefix with those extra options
+    # appended; the static pass installs the `.a`, the shared pass the
+    # dynamic lib, and headers are installed by both (idempotent). Other
+    # `generate_dynamic` packages emit both natively and leave this unset.
+    if shared_cmake_options:
+        shared_build_dir, shared_build_file = _cmake_generate(
+            name=package_name + '_generate_shared',
+            package_name=package_name + '_shared',
+            source_dir=source_dir,
+            install_dir=install_dir,
+            deps=[':' + target_unpack] + deps,
+            options=cmake_options + shared_cmake_options)
+        src_files.append(shared_build_file)
+        generate_deps.append(':' + package_name + '_generate_shared')
+        cmds.append(_cmd_with_log(
+            'make -C {dir} -j16 install'.format(dir=shared_build_dir),
+            log_file))
+    cmds.append(_EXPORT_HEADERS.format(install_dir=full_install_dir,
+                                       include_dir=strip_include_dir))
     gen_rule(name=name,
-             srcs=[build_file],
+             srcs=src_files,
              outs=build_outs,
              cmd=' && '.join(cmds),
              cmd_name='CMAKE BUILD',
-             deps=deps + [':' + target_generate],
+             deps=deps + generate_deps,
              generated_incs=package_name,
              # Same rationale as autotools_build above: third-party install
              # include dirs go via `-isystem` (blade 5b305b0+).

--- a/thirdparty/googletest/BUILD
+++ b/thirdparty/googletest/BUILD
@@ -10,8 +10,19 @@ cmake_build(
         '-DCMAKE_BUILD_TYPE=Release',
         '-DCMAKE_CXX_FLAGS=-Wno-deprecated-copy',
     ],
-    #patches=['generate_dynamic.patch'],
-    generate_dynamic=False,
+    # googletest's CMake emits either static or shared per configure (it keys
+    # solely off BUILD_SHARED_LIBS), so a single pass can't produce both. The
+    # static pass above yields libgtest.a (used by static_link consumers); this
+    # shared pass yields libgtest.dylib. Release builds default to dynamic_link
+    # (BLADE_ROOT), so cc_tests link the dylib -- giving gtest's UnitTest
+    # registry a single process-wide instance. Without a shared gtest, the
+    # static archive gets force_loaded (link_all_symbols) into every mock/main
+    # dylib, producing multiple registries where TEST() registers into one and
+    # RUN_ALL_TESTS() reads another ("does NOT link in any test case"). Using
+    # BUILD_SHARED_LIBS directly means the stale generate_dynamic.patch (written
+    # for 1.10) is no longer needed.
+    shared_cmake_options=['-DBUILD_SHARED_LIBS=ON'],
+    generate_dynamic=True,
 )
 
 foreign_cc_library(
@@ -21,7 +32,7 @@ foreign_cc_library(
         ':googletest_build',
     ],
     visibility='PUBLIC',
-    has_dynamic=False,
+    has_dynamic=True,
 )
 
 foreign_cc_library(
@@ -31,7 +42,7 @@ foreign_cc_library(
         ':googletest_build',
     ],
     visibility='PUBLIC',
-    has_dynamic=False,
+    has_dynamic=True,
 )
 
 foreign_cc_library(
@@ -40,7 +51,7 @@ foreign_cc_library(
         ':googletest_build',
     ],
     visibility='PUBLIC',
-    has_dynamic=False,
+    has_dynamic=True,
 )
 
 foreign_cc_library(
@@ -50,7 +61,7 @@ foreign_cc_library(
         ':googletest_build',
     ],
     visibility='PUBLIC',
-    has_dynamic=False,
+    has_dynamic=True,
 )
 
 cc_library(


### PR DESCRIPTION
## Problem

On macOS shared-library builds, several `:main`-based tests ran **zero** test cases and printed `This test program does NOT link in any test case`, despite defining real `TEST()`s:

- `//flare/testing:http_mock_test` (8 tests)
- `//flare/testing:cos_mock_test` (3 tests)
- `//flare/net/hbase:hbase_channel_test` (2 tests)

## Root cause

gtest was built **static-only**. Release builds default to `dynamic_link` (`BLADE_ROOT`), but with no `libgtest.dylib` the dynamic label fell back to `libgtest.a`, which then got force-loaded (`link_all_symbols`) into every mock/main dylib. Each dylib exported its **own copy** of gtest's `UnitTest` registry singleton, so `TEST()` registration bound to one copy while `RUN_ALL_TESTS()` (in `libmain.dylib`) read another. Whether a given test tripped this depended purely on dylib link order:

```
http_mock_test : libhttp_mock.dylib (gtest copy A) before libmain.dylib (gtest copy B) -> 0 tests
rpc_mock_test  : libmain.dylib       (gtest copy B) before librpc_mock.dylib            -> OK
```

## Fix

Ship a **shared** `libgtest` so the registry is a single process-wide instance. googletest's CMake keys solely off `BUILD_SHARED_LIBS` and emits *either* static *or* shared per configure, so one pass can't produce both.

- `thirdparty/foreign_build.bld`: add an optional second configure+install pass to `cmake_build` via `shared_cmake_options` (installs into the same prefix; unset for every other package, so they're untouched).
- `thirdparty/googletest/BUILD`: static pass keeps `libgtest.a` for `static_link` consumers; `shared_cmake_options=['-DBUILD_SHARED_LIBS=ON']` adds `libgtest.dylib` for `dynamic_link` ones.

No source patch — nothing to re-port on the next gtest bump. (The vendored `generate_dynamic.patch` was written for 1.10 and no longer applies to 1.17; it's now unused.)

## Verification

- Both `libgtest.a` + `libgtest.dylib` (and gmock/`*_main`) produced; `libgmock.dylib` -> `libgtest.dylib`.
- The three tests now link `libgtest.dylib` and **pass** (8/3/2).
- Ordinary `gtest_main` tests still pass (e.g. `uri_test`, `rpc_mock_test`).
- Full `//flare/...` build links clean (228 targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)