### PR TITLE
bazel: gate -lpthread/-ldl out on macOS to silence duplicate-library warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,14 @@ build:opt --compilation_mode=opt
 
 build --copt=-Wno-sign-compare
 
+# macOS: external deps (gflags/glog/protobuf/...) redundantly pass -lpthread/-lm,
+# which are no-ops on macOS (libSystem) but make Xcode 15+'s ld64 warn
+# "ignoring duplicate libraries". flare's own such linkopts are gated out in
+# BUILD files; this silences the residual from deps we don't control.
+# enable_platform_specific_config auto-applies the :macos config on macOS hosts.
+common --enable_platform_specific_config
+build:macos --linkopt=-Wl,-no_warn_duplicate_libraries
+
 # Silence warnings from third-party code while keeping flare's own warnings.
 # Covers both fetched deps (external/) and in-repo vendored libs (thirdparty/,
 # e.g. blake3, xxhash, rapidxml). `-w` is appended last so it wins.

--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,8 @@ build --copt=-Wno-sign-compare
 # enable_platform_specific_config auto-applies the :macos config on macOS hosts.
 common --enable_platform_specific_config
 build:macos --linkopt=-Wl,-no_warn_duplicate_libraries
+# Also cover exec/host-config links (build tools, e.g. protoc/codegen).
+build:macos --host_linkopt=-Wl,-no_warn_duplicate_libraries
 
 # Silence warnings from third-party code while keeping flare's own warnings.
 # Covers both fetched deps (external/) and in-repo vendored libs (thirdparty/,

--- a/flare/base/BUILD.bazel
+++ b/flare/base/BUILD.bazel
@@ -130,11 +130,11 @@ cc_library(
     name = "chrono",
     srcs = ["chrono.cc"],
     hdrs = ["chrono.h"],
-    linkopts = [
-        "-lpthread",
-    ] + select({
+    linkopts = select({
+        # On macOS pthread/rt live in libSystem; passing them is a no-op that
+        # only triggers ld64 "ignoring duplicate libraries" warnings.
         "@platforms//os:macos": [],
-        "//conditions:default": ["-lrt"],
+        "//conditions:default": ["-lpthread", "-lrt"],
     }),
     visibility = ["//visibility:public"],
     deps = [":align"],

--- a/flare/base/internal/BUILD.bazel
+++ b/flare/base/internal/BUILD.bazel
@@ -209,7 +209,12 @@ cc_library(
     name = "cpu",
     srcs = ["cpu.cc"],
     hdrs = ["cpu.h"],
-    linkopts = ["-ldl"],
+    # -ldl is a no-op on macOS (dlopen lives in libSystem); gate it out to
+    # avoid ld64 "ignoring duplicate libraries" warnings.
+    linkopts = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["-ldl"],
+    }),
     visibility = [
         "//flare:__subpackages__",
         # '//yadcc/...',  # FIXME: Move `cpu` out to `flare/base`.
@@ -236,7 +241,12 @@ cc_library(
     name = "curl",
     srcs = ["curl.cc"],
     hdrs = ["curl.h"],
-    linkopts = ["-ldl"],
+    # -ldl is a no-op on macOS (dlopen lives in libSystem); gate it out to
+    # avoid ld64 "ignoring duplicate libraries" warnings.
+    linkopts = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["-ldl"],
+    }),
     visibility = ["//flare:__subpackages__"],
     deps = [
         ":logging",


### PR DESCRIPTION
Fixes the noisy `ld: warning: ignoring duplicate libraries: '-ldl', '-lm', '-lpthread'` from the `build_on_macos` Bazel job.

On macOS, `-lpthread` / `-ldl` are no-ops — pthread and dlopen live in `libSystem`. Passing them is harmless but makes Xcode 15+'s ld64 warn about the duplicates as they propagate/aggregate across targets. This gates them out on macOS via `select()`, matching the `-lrt` handling already present in `flare/base:chrono`.

- `flare/base:chrono` — `-lpthread`
- `flare/base/internal:cpu`, `:curl` — `-ldl`

Validated with `bazel query` that the three targets still parse.

Note: a residual `-lm` (contributed by an external dependency, not this repo) may remain after this change. If CI still shows it, the catch-all is a `.bazelrc` macOS `--linkopt=-Wl,-no_warn_duplicate_libraries`, but I've kept this PR to the safe, definite cleanup first.

Closes #181