### PR TITLE
thirdparty/blade: update blade.zip — print progress without cursor control

### DIFF
--- a/thirdparty/blade/blade.zip
+++ b/thirdparty/blade/blade.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6aefa3e8b155206b81c454a42dd7ffc5778c3524a2dc983aaf0d0ddef7c1374b
-size 294342
+oid sha256:77cba1ad54838915c1ac87312d78ba12f9adb7de4fe9dbbead2c5832a3998596
+size 294781


### PR DESCRIPTION
Updates the vendored blade to master `168ce01` (blade-build#1334).

When the terminal has no cursor control — CI, a pipe, a dumb terminal — blade's live build panel can't render, so a long build looked stalled. blade now falls back to printing ninja's status lines (`[finished/total](running) <desc>`) as they arrive, keeping the build observable. This directly improves our own CI logs (the `build_*` jobs run with no TTY).

Honors `--quiet` and preserves the final `"N build steps completed"` summary.

Delta from the current vendored blade (`934eebb`): just blade-build#1334. Rebuilt via `dist_blade`.