### PR TITLE
thirdparty/protobuf: fix proto_test gtest include after vcpkg migration

### DIFF
--- a/thirdparty/protobuf/proto_test.cc
+++ b/thirdparty/protobuf/proto_test.cc
@@ -5,7 +5,7 @@
 
 #include <utility>
 
-#include "thirdparty/googletest/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 namespace gdt {
 


### PR DESCRIPTION
Hotfix for master: `build_on_ubuntu_24_04` failed in #187's post-merge CI —

```
thirdparty/protobuf/proto_test.cc:8:10: fatal error: thirdparty/googletest/gtest/gtest.h: No such file or directory
```

After gtest moved to vcpkg (#187), the old in-tree full path `thirdparty/googletest/gtest/gtest.h` no longer resolves (only `gtest_prod.h` remains in-tree; gtest headers come from vcpkg as `gtest/gtest.h`). macOS/22.04 passed on a cached `build64_release`; ubuntu-24.04 recompiled and caught it. The `cc_test` already pulls gtest via `cc_test_config.gtest_libs`, so this is just the include path. Verified with a clean recompile of `//thirdparty/protobuf:proto_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)