### PR TITLE
ci(test): mark overload/streaming RPC tests exclusive

### DIFF
--- a/flare/rpc/BUILD
+++ b/flare/rpc/BUILD
@@ -239,7 +239,10 @@ cc_test(
     '//flare/testing:main',
     '//thirdparty/gflags:gflags',
     '//thirdparty/jsoncpp:jsoncpp',
-  ]
+  ],
+  # Has overload tests that stress the whole server; under concurrent CI load
+  # they crash (SIGSEGV) / time out nondeterministically. Run alone.
+  exclusive = True,
 )
 
 cc_test(

--- a/flare/rpc/protocol/protobuf/BUILD
+++ b/flare/rpc/protocol/protobuf/BUILD
@@ -244,7 +244,10 @@ cc_test(
     '//flare/testing:echo_service_proto_flare',
     '//flare/testing:endpoint',
     '//flare/rpc:rpc',
-  ]
+  ],
+  # Streaming RPC stress: resource-heavy, flakes (SIGABRT/timeout) under
+  # concurrent CI load. Run alone.
+  exclusive = True,
 )
 
 cc_library(
@@ -297,6 +300,9 @@ cc_test(
     '//flare/testing:echo_service_proto_flare',
     '//flare/rpc:rpc',
   ],
+  # Streaming RPC stress: resource-heavy, flakes (SIGABRT/timeout) under
+  # concurrent CI load. Run alone.
+  exclusive = True,
 )
 
 cc_library(


### PR DESCRIPTION
These tests stress the whole machine and flake (SIGSEGV/SIGABRT/timeout) under concurrent CI load, though they pass in isolation — they've repeatedly turned master CI red this week. Marking them `exclusive` makes blade's scheduler run them alone.

- `flare/rpc:server_test` (overload tests)
- `flare/rpc/protocol/protobuf:proto_over_http_protocol_streaming_rpc_test`
- `flare/rpc/protocol/protobuf:std_protocol_streaming_rpc_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)