### PR TITLE
bazel/blade: drop hardcoded well_known_protos (auto-discover via blade #1339)

### DIFF
--- a/BLADE_ROOT
+++ b/BLADE_ROOT
@@ -148,20 +148,10 @@ proto_library_config(
     protobuf_path='',
     protobuf_incs=[],
     protoc_direct_dependencies=True,
-    well_known_protos=[
-        'google/protobuf/any.proto',
-        'google/protobuf/api.proto',
-        'google/protobuf/compiler/plugin.proto',
-        'google/protobuf/descriptor.proto',
-        'google/protobuf/duration.proto',
-        'google/protobuf/empty.proto',
-        'google/protobuf/field_mask.proto',
-        'google/protobuf/source_context.proto',
-        'google/protobuf/struct.proto',
-        'google/protobuf/timestamp.proto',
-        'google/protobuf/type.proto',
-        'google/protobuf/wrappers.proto',
-    ],
+    # well_known_protos left empty: blade auto-discovers the google/protobuf/*
+    # protos from the vcpkg#protobuf include tree (blade-build#1339), so the list
+    # stays correct across protobuf versions without hand-maintenance here.
+    well_known_protos=[],
 )
 
 # vcpkg-provided third-party libraries (issue blade-build#1236). Hands-on

--- a/thirdparty/blade/blade.zip
+++ b/thirdparty/blade/blade.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f76d9ab71155da2a8aee52beccc4437d2d3c1d79e0eb8b855fbfcdc1bc77cdb
-size 296262
+oid sha256:be214241e2bb938edcaf692ba964493fcc7fdd5da2017cf979fd956789a061c4
+size 297372


### PR DESCRIPTION
## What

[blade-build#1339](https://github.com/blade-build/blade-build/pull/1340) (merged) makes blade auto-discover the well-known protos (`google/protobuf/*.proto`) from the protobuf include tree when `proto_library_config.well_known_protos` is empty. With the `vcpkg#protobuf` provider that resolves to the installed `include/`, so the ~12-entry list no longer has to be hand-maintained in `BLADE_ROOT` and stays correct across protobuf versions.

This PR:
- empties `well_known_protos` in `BLADE_ROOT` (blade falls back to a built-in canonical set if the include tree is ever unresolvable, so there's no loss of robustness);
- vendors `thirdparty/blade/blade.zip` rebuilt from the merged blade master (the build that contains #1339).

## Validation

Local build with `VCPKG_ROOT` set:
- `flare/rpc:rpc_options_proto` (imports `google/protobuf/descriptor.proto`) builds; its `--direct_dependencies` is populated with exactly the same **12** `google/protobuf/*.proto` the hand-maintained list had — now discovered from the vcpkg protobuf install.
- `flare/rpc/...` (956 steps, proto-heavy) builds clean.

Context: removes the last bit of per-workspace protobuf boilerplate introduced by the vcpkg migration (#184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)