### PR TITLE
fiber: fix ASan SEGV on fiber switch (detect_stack_use_after_return) (#134)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,4 +37,11 @@ build:asan --config=san-common --copt=-fsanitize=address --linkopt=-fsanitize=ad
 # ASAN hits ODR violations with shared linkage due to rules_proto.
 build:asan --dynamic_mode=off
 
+# flare hand-switches pooled fiber stacks, which ASan's fake "use-after-return"
+# stacks (default-on since Clang 11) can't track -- the first fiber resume SEGVs
+# inside __sanitizer_start_switch_fiber (#134). The fiber runtime bakes this in
+# via __asan_default_options(); set it here too so it's explicit for `bazel
+# test` and survives a user-provided __asan_default_options override.
+build:asan --test_env=ASAN_OPTIONS=detect_stack_use_after_return=0
+
 test --test_output=errors

--- a/flare/fiber/detail/fiber_entity.cc
+++ b/flare/fiber/detail/fiber_entity.cc
@@ -36,6 +36,22 @@
 
 DECLARE_int32(flare_fiber_stack_size);
 
+#ifdef FLARE_INTERNAL_USE_ASAN
+// flare switches between pooled fiber stacks by hand. ASan's
+// `detect_stack_use_after_return` (on by default since Clang 11) gives each
+// function a separate "fake stack"; that bookkeeping cannot be followed across
+// our manual stack switch, so the first fiber resume crashes with a SEGV inside
+// `__sanitizer_start_switch_fiber` (Tencent/flare#134). Default the option off
+// for any binary that links the fiber runtime. The `ASAN_OPTIONS` environment
+// variable still overrides this, and every other ASan check stays enabled.
+//
+// Defined in this TU (rather than a standalone file) because it is always part
+// of the fiber runtime's link closure, so the linker won't drop it.
+extern "C" const char* __asan_default_options() {
+  return "detect_stack_use_after_return=0";
+}
+#endif
+
 namespace flare::fiber::detail {
 
 // Define thread-local variables declared in `fiber_entity.h`.


### PR DESCRIPTION
Fixes the ASan half of #134.

## Symptom

`bazel test --config=asan //flare/fiber:*` (clang) crashes on the **first fiber resume**:

```
AddressSanitizer: SEGV ... in flare::internal::asan::StartSwitchFiber(...) annotation.h
  #1 flare::fiber::detail::FiberEntity::Resume()       fiber_entity.cc
  #2 flare::fiber::detail::FiberEntity::ResumeOn(...)   fiber_entity.cc
  #3 flare::fiber::detail::FiberProc(void*)             fiber_entity.cc
```

## Root cause

ASan's **`detect_stack_use_after_return`** is **on by default since Clang 11**. It gives every function its own "fake stack". flare hand-switches between *pooled* fiber stacks; ASan's fake-stack bookkeeping cannot be followed across that manual switch, so `__sanitizer_start_switch_fiber` writes through a bad shadow address and the process dies.

I confirmed this empirically (clang-17) by toggling only that option:

| `ASAN_OPTIONS` | result |
|---|---|
| *(default — DSUAR on)* | **SEGV** |
| `detect_stack_use_after_return=0` | ✅ pass |
| `use_sigaltstack=0` (DSUAR still on) | **SEGV** |

It is independent of CPU arch (the original report is x86_64; I reproduced on aarch64) and of `--flare_fiber_stack_size` (tested 128 KiB → 8 MiB). Disabling DSUAR for fiber runtimes is the standard approach (Seastar, folly do the same) — DSUAR is fundamentally incompatible with manual switching of pooled stacks.

## Fix

Default `detect_stack_use_after_return=0` for any binary that links the fiber runtime:

1. **`__asan_default_options()`** in `fiber_entity.cc` (guarded by `FLARE_INTERNAL_USE_ASAN`). It lives in that TU because the fiber lib is always in the link closure, so the linker won't drop the symbol. **`ASAN_OPTIONS` still overrides it**, and every other ASan check stays on.
2. **`.bazelrc`** `build:asan` gets `--test_env=ASAN_OPTIONS=detect_stack_use_after_return=0` — explicit for `bazel test`, and it survives a user-provided `__asan_default_options`.

Trade-off (honest): stack-use-after-return detection is off process-wide; all other ASan checks remain.

## Verification (clang-17, `--config=asan`)

With `ASAN_OPTIONS` **unset** (proving the baked-in default alone works): `nm` shows `T __asan_default_options`, and these all pass —

- `future_test` (3), `fiber_test` (6), `timer_test` (5), `this_fiber_test` (2)

(Reproduced and verified in an Ubuntu 22.04 + clang-17 container.)

## Scope / follow-ups

- **ASan only.** The **TSan** crash in #134 has a *different* root cause (TSan shadow handling for switched fiber stacks — not a config toggle; unaffected by stack size) and remains open. I'd tackle it separately.
- No bazel CI lane is added here (flare's CI is currently blade-based). A `--config=asan //flare/fiber:...` regression-guard job could be a good follow-up if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)