### PR TITLE
fiber tests: sync waitable_test exclusive to bazel; cap fiber count under sanitizers (#199)

### DIFF
--- a/flare/fiber/detail/BUILD.bazel
+++ b/flare/fiber/detail/BUILD.bazel
@@ -197,6 +197,7 @@ cc_test(
 cc_test(
     name = "waitable_test",
     srcs = ["waitable_test.cc"],
+    tags = ["exclusive"],  # heavy; matches blade BUILD's exclusive=True
     deps = [
         ":fiber_impl",
         "//flare/base:random",

--- a/flare/fiber/detail/scheduling_group_test.cc
+++ b/flare/fiber/detail/scheduling_group_test.cc
@@ -23,6 +23,7 @@
 #include "gtest/gtest.h"
 
 #include "flare/base/chrono.h"
+#include "flare/base/internal/annotation.h"
 #include "flare/base/random.h"
 #include "flare/base/string.h"
 #include "flare/fiber/detail/fiber_entity.h"
@@ -46,11 +47,19 @@ template <class SG, class... Args>
 }
 
 std::size_t GetMaxFibers() {
+#if defined(FLARE_INTERNAL_USE_ASAN) || defined(FLARE_INTERNAL_USE_TSAN)
+  // Each fiber needs its own (mmap'd) stack; under ASan/TSan a full 128K-fiber
+  // run is both very slow (well past the test timeout) and memory-hungry. A
+  // smaller count still exercises the scheduling paths under instrumentation.
+  constexpr std::size_t kCap = 4096;
+#else
+  constexpr std::size_t kCap = 131072;
+#endif
   std::ifstream ifs("/proc/sys/vm/max_map_count");
   std::string s;
   std::getline(ifs, s);
   return std::min<std::size_t>(TryParse<std::size_t>(s).value_or(65530) / 4,
-                               131072);
+                               kCap);
 }
 
 FiberEntity* CreateFiberEntity(SchedulingGroup* sg, bool system_fiber,


### PR DESCRIPTION
Two small, independent fiber-test tweaks from triaging #199.

## Changes

1. **`waitable_test` exclusive sync.** It's `exclusive = True` in the blade `BUILD` but was missing `tags = ["exclusive"]` in `BUILD.bazel`. Sync them — it's a heavy test that shouldn't run concurrently with others (the contention also flaked neighbors like `latch_test` in sanitizer sweeps).

2. **Cap fiber count under sanitizers.** `scheduling_group_test`'s `GetMaxFibers()` returns up to **131072** fibers. Under ASan/TSan each fiber's stack makes that very slow (past the test timeout) and memory-hungry. Cap to **4096** when `FLARE_INTERNAL_USE_ASAN`/`_TSAN` is defined; still exercises the scheduling paths. Non-sanitized builds are unchanged (131072).

## Scope

These are hygiene fixes; they do **not** make the heavy fiber tests sanitizer-clean on their own — `waitable_test` and `scheduling_group_test` still hit the `use-after-poison` tracked in #199, which is a separate, deeper issue in the ASan **fiber-switch annotations** (same subsystem as #134). That root-cause analysis (incl. two experimentally-disproven fix hypotheses) is documented on #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)