### PR TITLE
base/internal: fix data race on JobQueue::node_id_ (TSan)

### DIFF
--- a/flare/base/internal/dpc.cc
+++ b/flare/base/internal/dpc.cc
@@ -96,7 +96,7 @@ class JobQueue : public RefCounted<JobQueue> {
         last_bookkeeping_.store(now, std::memory_order_relaxed);
 
         // Reset periodically, as the thread may be migrated by the system.
-        node_id_ = numa::GetCurrentNode();
+        node_id_.store(numa::GetCurrentNode(), std::memory_order_relaxed);
       }
     });
 
@@ -143,7 +143,9 @@ class JobQueue : public RefCounted<JobQueue> {
 
   void Release() noexcept { acquired_.store(false, std::memory_order_release); }
 
-  int GetNode() const noexcept { return node_id_; }
+  int GetNode() const noexcept {
+    return node_id_.load(std::memory_order_relaxed);
+  }
 
  private:
   struct Node;
@@ -179,8 +181,10 @@ class JobQueue : public RefCounted<JobQueue> {
     Function<void()> cb;
   };
 
-  // Reset periodically.
-  int node_id_{numa::GetCurrentNode()};
+  // Reset periodically. Read by the flusher (`GetNode()`) while the owner
+  // thread updates it; a stale read only picks a less-ideal NUMA queue, so a
+  // relaxed atomic (race-free, no ordering needed) is enough.
+  std::atomic<int> node_id_{numa::GetCurrentNode()};
 
   // Last time we freed not-freed-yet nodes.
   std::atomic<std::chrono::steady_clock::duration> last_bookkeeping_{};


### PR DESCRIPTION
## Problem

`flare::internal::JobQueue::node_id_` is a plain `int`. It's **written** by the queue's owner thread in `Push`'s periodic bookkeeping:

```cpp
node_id_ = numa::GetCurrentNode();   // dpc.cc, in Push()
```

and **read** concurrently by the flusher thread in `FlushDpcs`:

```cpp
BackgroundTaskHost::Instance()->Queue(queue->GetNode(), flush_cb);  // GetNode() returns node_id_
```

ThreadSanitizer flags this as a data race (size-4 read vs. write) and aborts (`exit -6`) any test that drives DPC — directly `flare/base/internal:dpc_test`, and indirectly the monitoring tests, which flush through `MonitoredTimer::FlushBufferedReports()` → `QueueDpc`.

## Fix

`node_id_` is only a **NUMA hint** (which `BackgroundTaskHost` queue to dispatch the flush callback to); a stale read just picks a less-ideal queue, never a wrong result. Make it a **relaxed `std::atomic<int>`** — race-free, no ordering required, no measurable cost.

## Verification
`flare/base/internal:dpc_test`, `flare/base:monitoring_test` (and the other monitoring tests) pass under `--sanitizer=thread`; normal build unaffected.