### PR TITLE
object_pool: drop over-alignment of TLS LocalPoolDescriptor (UBSan)

### DIFF
--- a/flare/base/object_pool/memory_node_shared.h
+++ b/flare/base/object_pool/memory_node_shared.h
@@ -111,7 +111,17 @@ struct GlobalPoolDescriptor {
 };
 
 // Thread-local object cache.
-struct alignas(hardware_destructive_interference_size) LocalPoolDescriptor {
+//
+// This used to be `alignas(hardware_destructive_interference_size)` to keep the
+// hot `objects` head off neighbouring cache lines, but the only instances live
+// in thread-local storage (see `GetLocalPoolDescriptor`), and TLS does not
+// honour over-alignment (> max_align_t) on several platforms (notably darwin)
+// -- so the object was placed misaligned and every member access was UB (caught
+// by UBSan), while the intended isolation never actually happened. Dropping the
+// over-alignment removes the UB at no real cost (the placement was never
+// aligned anyway). Proper cross-thread isolation here would need a different
+// mechanism.
+struct LocalPoolDescriptor {
   // See comments on `FixedVector` for the reason why `std::vector<...>` is not
   // used here.
   FixedVector objects;


### PR DESCRIPTION
## Problem

`LocalPoolDescriptor` is declared `alignas(hardware_destructive_interference_size)` (64B) to keep its hot `objects` head off neighbouring cache lines. But its only instances live in **thread-local storage** (`GetLocalPoolDescriptor`), and **TLS does not honour over-alignment** (> `max_align_t`) on several platforms — **darwin in particular**. So the object is actually placed *misaligned*, and every member access in `Get`/`Put` is undefined behaviour:

```
memory_node_shared.h: runtime error: member access within misaligned address
for type 'LocalPoolDescriptor', which requires 64 byte alignment
```

Because **every** allocation in flare goes through this pool, the single UB cascades and aborts **21 `flare/base` tests** under `--sanitizer=undefined` (crypto, buffer, monitoring, object_pool, net, …).

## Fix

Drop the over-alignment. Since TLS never honoured it, the intended false-sharing isolation **never actually happened** — so removing it:

- removes the UB **at no real cost** (the placement was never 64-aligned anyway), and
- keeps the existing **TLS storage semantics** — the descriptor's storage must outlive its own destructor, which poisons `current_`/`end_` so late `Put`s during thread teardown see `full()==true` and take the safe slow path. (A heap/`unique_ptr` alternative breaks this: freeing the descriptor at thread exit leaves `descriptors_ptr<T>.local` dangling → use-after-free.)

Real cross-thread isolation here would need a different, persistent-aligned-storage mechanism; noted in the comment for a future change.

## Verification
- `flare/base/... --sanitizer=undefined`: **all green** (was 21 failing)
- normal release build: unaffected