### PR TITLE
thirdparty: pin AR/RANLIB in autotools foreign builds (fix macOS jemalloc link)

### DIFF
--- a/thirdparty/foreign_build.bld
+++ b/thirdparty/foreign_build.bld
@@ -118,20 +118,30 @@ def _configure(name, package_name, source_dir, install_dir, with_packages, deps,
     # blade.cc_toolchain.tool() decided at config time.
     cc = blade.cc_toolchain.tool('cc') or 'cc'
     cxx = blade.cc_toolchain.tool('cxx') or 'c++'
+    # Pin the archiver too. blade.cc_toolchain.tool('ar') is the bare name `ar`,
+    # so an autotools package falls back to whatever `ar`/`ranlib` is first in
+    # PATH. On macOS a stray GNU/LLVM `ar` (e.g. from Homebrew binutils) there
+    # produces a GNU-format archive -- with `/` and `//` index members -- that
+    # Apple's ld then rejects at link time ("archive member '/' not a mach-o
+    # file"). Force the system BSD ar/ranlib, which emit a `__.SYMDEF` archive
+    # ld accepts. Off macOS, GNU archives are fine, so honor the toolchain ar.
+    ar = '/usr/bin/ar' if is_darwin else (blade.cc_toolchain.tool('ar') or 'ar')
+    ranlib = '/usr/bin/ranlib' if is_darwin else 'ranlib'
     configure = ('cd $OUT_DIR/%s && '
                  'LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH '
                  '%s'
-                 'CC=%s CXX=%s '
+                 'CC=%s CXX=%s AR=%s RANLIB=%s '
                  'LDFLAGS="$LDFLAGS %s" '
-                 './%s --prefix=%s %s' % (
+                 './%s --prefix=%s %s AR=%s RANLIB=%s' % (
                      source_dir,
                      lib_path_env,
                      dyld_path,
-                     cc, cxx,
+                     cc, cxx, ar, ranlib,
                      rpath_flags,
                      configure_file_name,
                      full_install_dir,
-                     configure_options))
+                     configure_options,
+                     ar, ranlib))
     if with_packages:
         for pkg in with_packages:
             pkg = pkg[1:]  # remove prefix ':'


### PR DESCRIPTION
## Problem
On macOS, `blade build //...` fails linking `je_server`:

```
ld: archive member '/' not a mach-o file in 'build_release/thirdparty/jemalloc/lib/libjemalloc.a'
```

`_configure` pins `CC`/`CXX` from the resolved toolchain but lets `AR`/`RANLIB` fall through to PATH. When a **GNU-format `ar`** sits ahead of `/usr/bin/ar` in PATH (Homebrew binutils, or an `llvm-ar` invoked in `--format=gnu` mode), a package built by a direct `$(AR) crus` Makefile rule produces a **GNU-format archive** (with `/` and `//` index members), which Apple's `ld` rejects.

## Why only jemalloc surfaced it
- **libtool-built** archives (libtcmalloc, jsoncpp, ctemplate — `_la-` object names) drive the archiver consistently → clean `__.SYMDEF` archives → fine.
- **Direct-`$(AR)`** archives (jemalloc; gperftools' profiler/tcmalloc_and_profiler) pick up the PATH `ar` → GNU format.
- Of those, only `libjemalloc.a` is in the **macOS** link graph (gperftools' profiler archives are gated Linux-only), so `je_server` was the only failure.

Verified Apple `ld` rejects both pure-GNU and GNU+ranlib-mixed archives — the format itself is the issue.

## Fix
Pin `AR`/`RANLIB` the same way `CC`/`CXX` already are: force the system BSD `/usr/bin/ar` + `/usr/bin/ranlib` on macOS (they emit a `__.SYMDEF` archive `ld` accepts), honor the toolchain `ar` elsewhere. Passed both as env and as autoconf precious-vars so the generated Makefile uses them.

Covers all `autotools_build` packages (jemalloc, gperftools, …).

## Validation
Clean rebuild on macOS:
- `Makefile` now has `AR = /usr/bin/ar`
- `libjemalloc.a` members: `__.SYMDEF SORTED` + objects (no `/`//`)
- `je_server` links; `_je_mallctl` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)