### PR TITLE
testing: drop SO_REUSEADDR from the port-availability probe

### DIFF
--- a/flare/testing/endpoint.cc
+++ b/flare/testing/endpoint.cc
@@ -27,9 +27,13 @@ bool IsPortAvaliable(uint16_t port, int type) {
   if (sock.Get() < 0) {
     return false;
   }
-  int reuse_flag = 1;
-  FLARE_PCHECK(setsockopt(sock.Get(), SOL_SOCKET, SO_REUSEADDR, &reuse_flag,
-                          sizeof(reuse_flag)) == 0);
+  // Deliberately do NOT set SO_REUSEADDR here. This is an availability probe,
+  // so it must see the port exactly as a fresh server bind would. With
+  // SO_REUSEADDR the probe can bind 0.0.0.0:port even while a concurrent test's
+  // server already holds 127.0.0.1:port, falsely reporting the port free and
+  // causing the caller's real bind to fail with EADDRINUSE under parallel test
+  // execution. Without it, an occupied port is correctly rejected and the
+  // caller retries another random port.
   auto ep = EndpointFromIpv4("0.0.0.0", port);
   return bind(sock.Get(), ep.Get(), ep.Length()) == 0;
 }


### PR DESCRIPTION
## Problem

`testing::PickAvailablePort()` / `PickAvailableEndpoint()` probe a candidate port by binding to it. The probe set `SO_REUSEADDR` before binding `0.0.0.0:port`. On macOS/BSD `SO_REUSEADDR` lets that bind succeed **even while another socket already holds `127.0.0.1:port`** — so the probe reports an occupied port as free. The caller then binds its real server to the same port and fails:

```
W socket.cc:150] Cannot bind socket to [127.0.0.1:5136]. : Address already in use [48]
F server.cc:226] Check failed: !!fd Cannot create listener.
```

This only bites under **parallel** test execution, where sibling tests hold ports concurrently (observed on `logging_test` running alongside `server_test` / `server_group_test` / `integration_test`). In isolation the test always passes.

## Fix

Drop `SO_REUSEADDR` from the probe. An availability probe must observe the port exactly as a fresh server bind would; with the override it doesn't. Without it, an occupied port is correctly rejected and `PickAvailablePort()` just retries another random port (no functional loss).

## Verification

- **Deterministic repro**: occupy `127.0.0.1:P` (no reuse); probe `0.0.0.0:P` *with* `SO_REUSEADDR` reports AVAILABLE (false positive), *without* it reports occupied (correct).
- **Stress**: ran the four port-grabbing rpc tests in parallel across many rounds — 0 flakes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)